### PR TITLE
Reduce the number of data copies

### DIFF
--- a/include/cdfpp/cdf-data.hpp
+++ b/include/cdfpp/cdf-data.hpp
@@ -36,6 +36,7 @@ namespace cdf
 struct cdf_none
 {
     bool operator==([[maybe_unused]] const cdf_none& other) const { return true; }
+    inline void* data() { return nullptr; }
 };
 
 using cdf_values_t = std::variant<cdf_none, std::vector<char>, std::vector<uint8_t>,
@@ -57,6 +58,12 @@ struct data_t
 
     template <typename type>
     decltype(auto) get() const;
+
+    const char* bytes_ptr() const;
+    char* bytes_ptr();
+
+    std::size_t size() const;
+    std::size_t bytes() const;
 
     CDF_Types type() const { return p_type; }
 
@@ -109,10 +116,9 @@ auto visit(const data_t& data, Ts... lambdas)
 }
 
 template <CDF_Types type, typename endianness_t>
-auto load_values(const char* buffer, std::size_t buffer_size);
+auto load_values(data_t& data);
 
-data_t load_values(
-    const char* buffer, std::size_t buffer_size, CDF_Types type, cdf_encoding encoding);
+data_t load_values(data_t& data, cdf_encoding encoding);
 
 
 /*=================================================================================
@@ -189,57 +195,44 @@ std::vector<T> iso_8859_1_to_utf8(const char* buffer, std::size_t buffer_size)
 
 
 template <CDF_Types type, typename endianness_t, bool latin1_to_utf8_conv>
-inline auto load_values(const char* buffer, std::size_t buffer_size)
+inline data_t load_values(data_t&& data)
 {
-
-    CDFPP_ASSERT(not(buffer == nullptr and buffer_size != 0UL));
 
     if constexpr (type == CDF_Types::CDF_CHAR
         || type == CDF_Types::CDF_UCHAR) // special case for strings
     {
         if constexpr (latin1_to_utf8_conv)
         {
-            return iso_8859_1_to_utf8<from_cdf_type_t<type>>(buffer, buffer_size);
+            return data_t { cdf_values_t { iso_8859_1_to_utf8<from_cdf_type_t<type>>(
+                                data.bytes_ptr(), data.bytes()) },
+                type };
         }
         else
         {
-            std::vector<from_cdf_type_t<type>> result(buffer_size, '\0');
-            std::transform(buffer, buffer + buffer_size, std::begin(result),
-                [](const auto c) { return static_cast<from_cdf_type_t<type>>(c); });
-            return result;
+            return std::move(data);
         }
     }
     else
     {
-        using raw_type = from_cdf_type_t<type>;
-        std::size_t size = buffer_size / sizeof(raw_type);
-        std::vector<raw_type> result(size);
-        if (size != 0UL)
-            endianness::decode_v<endianness_t>(buffer, buffer_size, result.data());
-        return cdf_values_t { std::move(result) };
+        if (std::size(data) != 0UL)
+            endianness::decode_v<endianness_t>(data.bytes_ptr(), data.bytes(), data.bytes_ptr());
+        return std::move(data);
     }
 }
 
 template <bool iso_8859_1_to_utf8>
-inline data_t load_values(
-    const char* buffer, std::size_t buffer_size, CDF_Types type, cdf_encoding encoding)
+inline data_t load_values(data_t&& data, cdf_encoding encoding)
 {
-    CDFPP_ASSERT(not(buffer == nullptr and buffer_size != 0UL));
 #define DATA_FROM_T(type)                                                                          \
     case CDF_Types::type:                                                                          \
         if (endianness::is_big_endian_encoding(encoding))                                          \
-            return data_t {                                                                        \
-                load_values<CDF_Types::type, endianness::big_endian_t, iso_8859_1_to_utf8>(        \
-                    buffer, buffer_size),                                                          \
-                CDF_Types::type                                                                    \
-            };                                                                                     \
-        return data_t {                                                                            \
-            load_values<CDF_Types::type, endianness::little_endian_t, iso_8859_1_to_utf8>(         \
-                buffer, buffer_size),                                                              \
-            CDF_Types::type                                                                        \
-        };
+            return load_values<CDF_Types::type, endianness::big_endian_t, iso_8859_1_to_utf8>(     \
+                std::move(data));                                                                  \
+        return load_values<CDF_Types::type, endianness::little_endian_t, iso_8859_1_to_utf8>(      \
+            std::move(data));
 
-    switch (type)
+
+    switch (data.type())
     {
         DATA_FROM_T(CDF_FLOAT)
         DATA_FROM_T(CDF_DOUBLE)
@@ -262,6 +255,271 @@ inline data_t load_values(
             return {};
     }
     return {};
+}
+
+template <CDF_Types type>
+cdf_values_t new_cdf_values_container(std::size_t len)
+{
+    using raw_type = from_cdf_type_t<type>;
+    std::size_t size = len / sizeof(raw_type);
+    return cdf_values_t { std::vector<raw_type>(size) };
+}
+
+
+inline data_t new_data_container(std::size_t bytes_len, CDF_Types type)
+{
+#define DC_FROM_T(type)                                                                            \
+    case CDF_Types::type:                                                                          \
+        return data_t { new_cdf_values_container<CDF_Types::type>(bytes_len), CDF_Types::type };
+
+    switch (type)
+    {
+        DC_FROM_T(CDF_FLOAT)
+        DC_FROM_T(CDF_DOUBLE)
+        DC_FROM_T(CDF_REAL4)
+        DC_FROM_T(CDF_REAL8)
+        DC_FROM_T(CDF_EPOCH)
+        DC_FROM_T(CDF_EPOCH16)
+        DC_FROM_T(CDF_TIME_TT2000)
+        DC_FROM_T(CDF_CHAR)
+        DC_FROM_T(CDF_UCHAR)
+        DC_FROM_T(CDF_INT1)
+        DC_FROM_T(CDF_INT2)
+        DC_FROM_T(CDF_INT4)
+        DC_FROM_T(CDF_INT8)
+        DC_FROM_T(CDF_UINT1)
+        DC_FROM_T(CDF_UINT2)
+        DC_FROM_T(CDF_UINT4)
+        DC_FROM_T(CDF_BYTE)
+        case CDF_Types::CDF_NONE:
+            return {};
+    }
+    return {};
+}
+
+
+inline const char* data_t::bytes_ptr() const
+{
+    switch (this->type())
+    {
+        case cdf::CDF_Types::CDF_BYTE:
+        case cdf::CDF_Types::CDF_INT1:
+            return reinterpret_cast<const char*>(this->get<int8_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_UINT1:
+            return reinterpret_cast<const char*>(this->get<uint8_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_INT2:
+            return reinterpret_cast<const char*>(this->get<int16_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_INT4:
+            return reinterpret_cast<const char*>(this->get<int32_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_INT8:
+            return reinterpret_cast<const char*>(this->get<int64_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_UINT2:
+            return reinterpret_cast<const char*>(this->get<uint16_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_UINT4:
+            return reinterpret_cast<const char*>(this->get<uint32_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_DOUBLE:
+        case cdf::CDF_Types::CDF_REAL8:
+            return reinterpret_cast<const char*>(this->get<double>().data());
+            break;
+        case cdf::CDF_Types::CDF_FLOAT:
+        case cdf::CDF_Types::CDF_REAL4:
+            return reinterpret_cast<const char*>(this->get<float>().data());
+            break;
+        case cdf::CDF_Types::CDF_EPOCH:
+            return reinterpret_cast<const char*>(this->get<epoch>().data());
+            break;
+        case cdf::CDF_Types::CDF_EPOCH16:
+            return reinterpret_cast<const char*>(this->get<epoch16>().data());
+            break;
+        case cdf::CDF_Types::CDF_TIME_TT2000:
+            return reinterpret_cast<const char*>(this->get<tt2000_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_UCHAR:
+            return reinterpret_cast<const char*>(this->get<cdf::CDF_Types::CDF_UCHAR>().data());
+            break;
+        case cdf::CDF_Types::CDF_CHAR:
+            return reinterpret_cast<const char*>(this->get<cdf::CDF_Types::CDF_CHAR>().data());
+            break;
+        default:
+            return nullptr;
+            break;
+    }
+    return nullptr;
+}
+
+inline char* data_t::bytes_ptr()
+{
+    switch (this->type())
+    {
+        case cdf::CDF_Types::CDF_BYTE:
+        case cdf::CDF_Types::CDF_INT1:
+            return reinterpret_cast<char*>(this->get<int8_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_UINT1:
+            return reinterpret_cast<char*>(this->get<uint8_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_INT2:
+            return reinterpret_cast<char*>(this->get<int16_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_INT4:
+            return reinterpret_cast<char*>(this->get<int32_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_INT8:
+            return reinterpret_cast<char*>(this->get<int64_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_UINT2:
+            return reinterpret_cast<char*>(this->get<uint16_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_UINT4:
+            return reinterpret_cast<char*>(this->get<uint32_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_DOUBLE:
+        case cdf::CDF_Types::CDF_REAL8:
+            return reinterpret_cast<char*>(this->get<double>().data());
+            break;
+        case cdf::CDF_Types::CDF_FLOAT:
+        case cdf::CDF_Types::CDF_REAL4:
+            return reinterpret_cast<char*>(this->get<float>().data());
+            break;
+        case cdf::CDF_Types::CDF_EPOCH:
+            return reinterpret_cast<char*>(this->get<epoch>().data());
+            break;
+        case cdf::CDF_Types::CDF_EPOCH16:
+            return reinterpret_cast<char*>(this->get<epoch16>().data());
+            break;
+        case cdf::CDF_Types::CDF_TIME_TT2000:
+            return reinterpret_cast<char*>(this->get<tt2000_t>().data());
+            break;
+        case cdf::CDF_Types::CDF_UCHAR:
+            return reinterpret_cast<char*>(this->get<cdf::CDF_Types::CDF_UCHAR>().data());
+            break;
+        case cdf::CDF_Types::CDF_CHAR:
+            return reinterpret_cast<char*>(this->get<cdf::CDF_Types::CDF_CHAR>().data());
+            break;
+        default:
+            return nullptr;
+            break;
+    }
+    return nullptr;
+}
+
+inline std::size_t data_t::size() const
+{
+    switch (this->type())
+    {
+        case cdf::CDF_Types::CDF_BYTE:
+        case cdf::CDF_Types::CDF_INT1:
+            return std::size(this->get<int8_t>());
+            break;
+        case cdf::CDF_Types::CDF_UINT1:
+            return std::size(this->get<uint8_t>());
+            break;
+        case cdf::CDF_Types::CDF_INT2:
+            return std::size(this->get<int16_t>());
+            break;
+        case cdf::CDF_Types::CDF_INT4:
+            return std::size(this->get<int32_t>());
+            break;
+        case cdf::CDF_Types::CDF_INT8:
+            return std::size(this->get<int64_t>());
+            break;
+        case cdf::CDF_Types::CDF_UINT2:
+            return std::size(this->get<uint16_t>());
+            break;
+        case cdf::CDF_Types::CDF_UINT4:
+            return std::size(this->get<uint32_t>());
+            break;
+        case cdf::CDF_Types::CDF_DOUBLE:
+        case cdf::CDF_Types::CDF_REAL8:
+            return std::size(this->get<double>());
+            break;
+        case cdf::CDF_Types::CDF_FLOAT:
+        case cdf::CDF_Types::CDF_REAL4:
+            return std::size(this->get<float>());
+            break;
+        case cdf::CDF_Types::CDF_EPOCH:
+            return std::size(this->get<epoch>());
+            break;
+        case cdf::CDF_Types::CDF_EPOCH16:
+            return std::size(this->get<epoch16>());
+            break;
+        case cdf::CDF_Types::CDF_TIME_TT2000:
+            return std::size(this->get<tt2000_t>());
+            break;
+        case cdf::CDF_Types::CDF_UCHAR:
+            return std::size(this->get<cdf::CDF_Types::CDF_UCHAR>());
+            break;
+        case cdf::CDF_Types::CDF_CHAR:
+            return std::size(this->get<cdf::CDF_Types::CDF_CHAR>());
+            break;
+        default:
+            return 0;
+            break;
+    }
+    return 0;
+}
+
+inline std::size_t data_t::bytes() const
+{
+    switch (this->type())
+    {
+        case cdf::CDF_Types::CDF_BYTE:
+        case cdf::CDF_Types::CDF_INT1:
+            return std::size(this->get<int8_t>());
+            break;
+        case cdf::CDF_Types::CDF_UINT1:
+            return std::size(this->get<uint8_t>());
+            break;
+        case cdf::CDF_Types::CDF_INT2:
+            return std::size(this->get<int16_t>()) * 2;
+            break;
+        case cdf::CDF_Types::CDF_INT4:
+            return std::size(this->get<int32_t>()) * 4;
+            break;
+        case cdf::CDF_Types::CDF_INT8:
+            return std::size(this->get<int64_t>()) * 8;
+            break;
+        case cdf::CDF_Types::CDF_UINT2:
+            return std::size(this->get<uint16_t>()) * 2;
+            break;
+        case cdf::CDF_Types::CDF_UINT4:
+            return std::size(this->get<uint32_t>()) * 4;
+            break;
+        case cdf::CDF_Types::CDF_DOUBLE:
+        case cdf::CDF_Types::CDF_REAL8:
+            return std::size(this->get<double>()) * 8;
+            break;
+        case cdf::CDF_Types::CDF_FLOAT:
+        case cdf::CDF_Types::CDF_REAL4:
+            return std::size(this->get<float>()) * 4;
+            break;
+        case cdf::CDF_Types::CDF_EPOCH:
+            return std::size(this->get<epoch>()) * sizeof(epoch);
+            break;
+        case cdf::CDF_Types::CDF_EPOCH16:
+            return std::size(this->get<epoch16>()) * sizeof(epoch16);
+            break;
+        case cdf::CDF_Types::CDF_TIME_TT2000:
+            return std::size(this->get<tt2000_t>()) * sizeof(tt2000_t);
+            break;
+        case cdf::CDF_Types::CDF_UCHAR:
+            return std::size(this->get<cdf::CDF_Types::CDF_UCHAR>());
+            break;
+        case cdf::CDF_Types::CDF_CHAR:
+            return std::size(this->get<cdf::CDF_Types::CDF_CHAR>());
+            break;
+        default:
+            return 0;
+            break;
+    }
+    return 0;
 }
 
 }

--- a/include/cdfpp/cdf-endianness.hpp
+++ b/include/cdfpp/cdf-endianness.hpp
@@ -108,13 +108,25 @@ namespace
     using uint_t = typename uint<s>::type;
 
 
-    inline uint8_t bswap(uint8_t v) { return v; }
-    inline uint16_t bswap(uint16_t v) { return bswap16(v); }
-    inline uint32_t bswap(uint32_t v) { return bswap32(v); }
-    inline uint64_t bswap(uint64_t v) { return bswap64(v); }
+    inline uint8_t bswap(uint8_t v)
+    {
+        return v;
+    }
+    inline uint16_t bswap(uint16_t v)
+    {
+        return bswap16(v);
+    }
+    inline uint32_t bswap(uint32_t v)
+    {
+        return bswap32(v);
+    }
+    inline uint64_t bswap(uint64_t v)
+    {
+        return bswap64(v);
+    }
 
     template <typename T, std::size_t s = sizeof(T)>
-    T byte_swap(T value)
+    inline T byte_swap(T value)
     {
         using int_repr_t = uint_t<s>;
         int_repr_t result = bswap(*reinterpret_cast<int_repr_t*>(&value));
@@ -144,13 +156,21 @@ inline void decode_v(const char* input, std::size_t size, value_t* output)
     using casted_buffer_t = uint_t<sizeof(value_t)>;
     CDFPP_ASSERT(input != nullptr);
     CDFPP_ASSERT(output != nullptr);
-    std::memcpy(output, input, size);
-    if constexpr (not std::is_same_v<host_endianness_t, src_endianess_t>)
+    if (size > 0)
     {
-        std::size_t buffer_size = size / sizeof(value_t);
-        casted_buffer_t* casted_buffer = reinterpret_cast<casted_buffer_t*>(output);
-        std::transform(casted_buffer, casted_buffer + buffer_size, casted_buffer,
-            [](const auto& v) { return byte_swap(v); });
+        if (reinterpret_cast<const void*>(output) != reinterpret_cast<const void*>(input))
+        {
+            std::memcpy(output, input, size);
+        }
+        if constexpr (not std::is_same_v<host_endianness_t, src_endianess_t>)
+        {
+            std::size_t buffer_size = size / sizeof(value_t);
+            casted_buffer_t* casted_buffer = reinterpret_cast<casted_buffer_t*>(output);
+            for (auto i = 0UL; i < buffer_size; i++)
+            {
+                casted_buffer[i] = byte_swap(casted_buffer[i]);
+            }
+        }
     }
 }
 

--- a/include/cdfpp/cdf-io/cdf-io-attribute.hpp
+++ b/include/cdfpp/cdf-io/cdf-io-attribute.hpp
@@ -37,10 +37,12 @@ Attribute::attr_data_t load_data(
         [&](auto& AEDR)
         {
             std::size_t element_size = cdf_type_size(CDF_Types { AEDR.DataType.value });
-            auto data
-                = buffer.read(AEDR.offset + AEDR.Values.offset, AEDR.NumElements * element_size);
+            data_t data = new_data_container(
+                AEDR.NumElements * element_size, CDF_Types { AEDR.DataType.value });
+            buffer.read(data.bytes_ptr(), AEDR.offset + AEDR.Values.offset,
+                AEDR.NumElements * element_size);
             values.emplace_back(
-                load_values<iso_8859_1_to_utf8>(data.data(), std::size(data), AEDR.DataType.value, context.encoding()));
+                load_values<iso_8859_1_to_utf8>(std::move(data), context.encoding()));
             var_num.push_back(AEDR.Num.value);
         });
     return values;


### PR DESCRIPTION
Since we always know the variable or attribute values size before loading them we can pre allocate them and read values in place.