### PR TITLE
Attributes values reset

### DIFF
--- a/include/cdfpp/attribute.hpp
+++ b/include/cdfpp/attribute.hpp
@@ -155,6 +155,91 @@ struct Attribute
 private:
     attr_data_t data;
 };
+
+struct VariableAttribute
+{
+    using attr_data_t = data_t;
+    std::string name;
+    VariableAttribute() = default;
+    VariableAttribute(const VariableAttribute&) = default;
+    VariableAttribute(VariableAttribute&&) = default;
+    VariableAttribute& operator=(VariableAttribute&&) = default;
+    VariableAttribute& operator=(const VariableAttribute&) = default;
+    VariableAttribute(const std::string& name, attr_data_t&& data) : name { name }
+    {
+        this->data = std::move(data);
+    }
+
+    inline bool operator==(const VariableAttribute& other) const
+    {
+        return other.name == name && other.data == data;
+    }
+
+    inline bool operator!=(const VariableAttribute& other) const { return !(*this == other); }
+
+    inline CDF_Types type() const noexcept { return data.type(); }
+
+    template <CDF_Types type>
+    [[nodiscard]] inline decltype(auto) get()
+    {
+        return data.get<type>();
+    }
+
+    template <CDF_Types type>
+    [[nodiscard]] inline decltype(auto) get() const
+    {
+        return data.get<type>();
+    }
+
+    template <typename type>
+    [[nodiscard]] inline decltype(auto) get()
+    {
+        return data.get<type>();
+    }
+
+    template <typename type>
+    [[nodiscard]] inline decltype(auto) get() const
+    {
+        return data.get<type>();
+    }
+
+    inline void swap(data_t& new_data) { std::swap(data, new_data); }
+
+    inline VariableAttribute& operator=(attr_data_t& new_data)
+    {
+        data = new_data;
+        return *this;
+    }
+
+    inline VariableAttribute& operator=(attr_data_t&& new_data)
+    {
+        data = new_data;
+        return *this;
+    }
+
+    inline data_t& operator*() { return data; }
+    inline const data_t& operator*()const { return data; }
+
+    [[nodiscard]] inline data_t& value() { return data; }
+    [[nodiscard]] inline const data_t& value() const { return data; }
+
+    template <typename... Ts>
+    friend void visit(Attribute& attr, Ts... lambdas);
+
+    template <typename... Ts>
+    friend void visit(const Attribute& attr, Ts... lambdas);
+
+    template <class stream_t>
+    inline stream_t& __repr__(stream_t& os, indent_t indent = {}) const
+    {
+        os << indent << name << ": " << data << std::endl;
+        return os;
+    }
+
+private:
+    data_t data;
+};
+
 template <typename... Ts>
 void visit(Attribute& attr, Ts... lambdas)
 {
@@ -173,6 +258,12 @@ void visit(const Attribute& attr, Ts... lambdas)
 
 template <class stream_t>
 inline stream_t& operator<<(stream_t& os, const cdf::Attribute& attribute)
+{
+    return attribute.template __repr__<stream_t>(os);
+}
+
+template <class stream_t>
+inline stream_t& operator<<(stream_t& os, const cdf::VariableAttribute& attribute)
 {
     return attribute.template __repr__<stream_t>(os);
 }

--- a/include/cdfpp/cdf-file.hpp
+++ b/include/cdfpp/cdf-file.hpp
@@ -35,6 +35,14 @@ inline stream_t& operator<<(stream_t& os, const cdf_map<std::string, cdf::Variab
     return os;
 }
 
+template <class stream_t>
+inline stream_t& operator<<(stream_t& os, const cdf_map<std::string, cdf::Attribute>& attributes)
+{
+    std::for_each(std::cbegin(attributes), std::cend(attributes),
+        [&os](const auto& item) { item.second.__repr__(os, indent_t {}); });
+    return os;
+}
+
 
 namespace cdf
 {

--- a/include/cdfpp/cdf-io/common.hpp
+++ b/include/cdfpp/cdf-io/common.hpp
@@ -110,7 +110,7 @@ struct cdf_repr
     std::tuple<uint32_t, uint32_t, uint32_t> distribution_version;
     cdf_map<std::string, Variable> variables;
     cdf_map<std::string, Attribute> attributes;
-    std::vector<cdf_map<std::string, Attribute>> var_attributes;
+    std::vector<cdf_map<std::string, VariableAttribute>> var_attributes;
     cdf_majority majority;
     cdf_compression_type compression_type;
     bool lazy;
@@ -127,19 +127,19 @@ void add_global_attribute(cdf_repr& repr, const std::string& name, Attribute::at
 }
 
 void add_var_attribute(cdf_repr& repr, const std::vector<uint32_t>& variable_indexes,
-    const std::string& name, Attribute::attr_data_t&& data)
+    const std::string& name, std::vector<VariableAttribute::attr_data_t>&& data)
 {
     assert(std::size(data) == std::size(variable_indexes));
-    cdf_map<uint32_t, cdf_map<std::string, Attribute::attr_data_t>> storage;
+    cdf_map<uint32_t, cdf_map<std::string, VariableAttribute::attr_data_t>> storage;
     for (auto index = 0UL; index < std::size(data); index++)
     {
-        storage[variable_indexes[index]][name].push_back(data[index]);
+        storage[variable_indexes[index]][name] = data[index];
     }
     for (auto& [v_index, attr] : storage)
     {
         for (auto& [attr_name, attr_data] : attr)
         {
-            repr.var_attributes[v_index][attr_name] = Attribute { attr_name, std::move(attr_data) };
+            repr.var_attributes[v_index][attr_name] = VariableAttribute { attr_name, std::move(attr_data) };
         }
     }
 }

--- a/include/cdfpp/cdf-io/saving/create_records.hpp
+++ b/include/cdfpp/cdf-io/saving/create_records.hpp
@@ -127,7 +127,7 @@ namespace saving
             auto& vac = svg_ctx.body.variable_attributes[name];
             update_size(vac.adr);
             vac.attrs.push_back(&attribute);
-            const auto& data = attribute[0UL];
+            const auto& data = *attribute;
             auto& aedr = vac.aedrs.emplace_back(cdf_AzEDR_t<v3x_tag> { {}, 0, vac.adr.record.num,
                 data.type(), static_cast<int32_t>(variable.number), 0, 0, 0, 0, 0, 0 });
             if (is_string(data.type()))

--- a/include/cdfpp/cdf-io/saving/records-saving.hpp
+++ b/include/cdfpp/cdf-io/saving/records-saving.hpp
@@ -91,7 +91,7 @@ struct file_attribute_ctx
 struct variable_attribute_ctx
 {
     int32_t number;
-    std::vector<const Attribute*> attrs;
+    std::vector<const VariableAttribute*> attrs;
     record_wrapper<cdf_ADR_t<v3x_tag>> adr;
     std::vector<record_wrapper<cdf_AzEDR_t<v3x_tag>>> aedrs;
 };

--- a/include/cdfpp/cdf-io/saving/saving.hpp
+++ b/include/cdfpp/cdf-io/saving/saving.hpp
@@ -86,7 +86,7 @@ namespace saving
     }
 
     template <typename U>
-    void write_records(const std::vector<const Attribute*> attrs,
+    void write_records(const std::vector<const VariableAttribute*> attrs,
         const std::vector<record_wrapper<cdf_AzEDR_t<v3x_tag>>>& aedrs, U&& writer,
         std::size_t virtual_offset = 0)
     {
@@ -96,7 +96,7 @@ namespace saving
             auto& aedr = aedrs[i];
             auto& attr = *attrs[i];
             save_record(aedr.record, writer);
-            const auto& values = attr[0];
+            const auto& values = *attr;
             auto offset = writer.write(values.bytes_ptr(), values.bytes()) + virtual_offset;
             assert(offset - aedr.size == aedr.offset);
         }

--- a/include/cdfpp/variable.hpp
+++ b/include/cdfpp/variable.hpp
@@ -34,7 +34,7 @@
 #include <vector>
 
 template <class stream_t>
-inline stream_t& operator<<(stream_t& os, const cdf_map<std::string, cdf::Attribute>& attributes)
+inline stream_t& operator<<(stream_t& os, const cdf_map<std::string, cdf::VariableAttribute>& attributes)
 {
     std::for_each(std::cbegin(attributes), std::cend(attributes),
         [&os](const auto& item) { item.second.__repr__(os, indent_t {}); });
@@ -68,7 +68,7 @@ struct Variable
 {
     using var_data_t = data_t;
     using shape_t = no_init_vector<uint32_t>;
-    cdf_map<std::string, Attribute> attributes;
+    cdf_map<std::string, VariableAttribute> attributes;
     Variable() = default;
     Variable(Variable&&) = default;
     Variable(const Variable&) = default;

--- a/pycdfpp/pycdfpp.cpp
+++ b/pycdfpp/pycdfpp.cpp
@@ -45,6 +45,7 @@ using namespace cdf;
 #include <fmt/ranges.h>
 
 PYBIND11_MAKE_OPAQUE(cdf_map<std::string, Attribute>);
+PYBIND11_MAKE_OPAQUE(cdf_map<std::string, VariableAttribute>);
 PYBIND11_MAKE_OPAQUE(cdf_map<std::string, Variable>);
 
 namespace py = pybind11;
@@ -102,6 +103,7 @@ PYBIND11_MODULE(_pycdfpp, m)
 
     def_cdf_map<std::string, Variable>(m, "VariablesMap");
     def_cdf_map<std::string, Attribute>(m, "AttributeMap");
+    def_cdf_map<std::string, VariableAttribute>(m, "VariableAttributeMap");
 
 
     def_attribute_wrapper(m);

--- a/pycdfpp/variable.hpp
+++ b/pycdfpp/variable.hpp
@@ -242,7 +242,7 @@ void def_variable_wrapper(T& mod)
         .def_property_readonly("values_encoded", make_values_view<true>, py::keep_alive<0, 1>())
         .def("_set_values", set_values, py::arg("values").noconvert(), py::arg("data_type"))
         .def("_add_attribute",
-            static_cast<Attribute& (*)(Variable&, const std::string&, const string_or_buffer_t&,
+            static_cast<VariableAttribute& (*)(Variable&, const std::string&, const string_or_buffer_t&,
                 CDF_Types)>(add_attribute),
             py::arg { "name" }, py::arg { "values" }, py::arg { "data_type" },
             py::return_value_policy::reference_internal);

--- a/tests/python_saving/test.py
+++ b/tests/python_saving/test.py
@@ -33,9 +33,22 @@ class PycdfCreateCDFTest(unittest.TestCase):
     def test_compare_differents_cdfs(self):
         self.assertEqual(make_cdf(),pycdfpp.CDF())
 
-    def test_inmemory_save_load_empty_CDF_object(self):
+    def test_in_memory_save_load_empty_CDF_object(self):
         cdf = pycdfpp.CDF()
         self.assertIsNotNone(pycdfpp.load(pycdfpp.save(cdf)))
+
+    def test_overwrite_attribute(self):
+        cdf = make_cdf()
+        self.assertEqual(cdf.attributes["test_attribute"][0], [1,2,3])
+        self.assertEqual(cdf.attributes["test_attribute"][2], "hello\nworld")
+        cdf.attributes["test_attribute"].set_values(["hello\nworld", [datetime(2018,1,1), datetime(2018,1,2)], [1,2,3]])
+        self.assertEqual(cdf.attributes["test_attribute"][0], "hello\nworld")
+        self.assertEqual(cdf.attributes["test_attribute"][2], [1,2,3])
+
+        cdf["test_variable"].attributes["attr1"].set_value([3,2,1])
+        self.assertEqual(cdf["test_variable"].attributes["attr1"][0], [3,2,1])
+        self.assertEqual(cdf["test_variable"].attributes["attr1"].value, [3,2,1])
+
 
     def test_can_create_CDF_attributes(self):
         cdf = pycdfpp.CDF()


### PR DESCRIPTION
This patch allows to reset attributes values, this makes sense when building CDFs from masters or skeletons where you want all attributes to appear in the master or skeleton but the actual value is known or reset later while producing actual CDFs.