### PR TITLE
Better CDF/ISTP Special Values support 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
       - g++
       - ninja-build
    tools:
-      python: "3.11"
+      python: "3.12"
       # You can also specify other tool versions:
       # nodejs: "19"
       # rust: "1.64"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,3 +104,39 @@ Creating a basic CDF file:
     pycdfpp.save(cdf, "some_cdf.cdf")
 
 
+
+FAQ
+===
+
+How to control integer attributes types?
+----------------------------------------
+
+Use numpy types to control the type of integer attributes:
+
+.. code-block:: python
+
+    import pycdfpp
+    import numpy as np
+
+    cdf = pycdfpp.CDF()
+    cdf.add_attribute("int8 attribute",  np.array([[1, 2, 3]], dtype=np.int8))
+    cdf.add_attribute("int16 attribute", np.array([[1, 2, 3]], dtype=np.int16))
+    cdf.add_attribute("int32 attribute", np.array([[1, 2, 3]], dtype=np.int32))
+    cdf.add_attribute("int64 attribute", np.array([[1, 2, 3]], dtype=np.int64))
+
+    # or:
+    cdf.add_attribute("int8 attribute2", [[np.int8(1)]])
+
+How to make special values (FILLVAL, Pad valuse, etc.)?
+-------------------------------------------------------
+
+Use the `pycdfpp.default_fill_value` and `pycdfpp.default_pad_value` functions to create Fill or Pad values depending on the CDF type:
+
+.. code-block:: python
+
+    import pycdfpp
+    import numpy as np
+
+    cdf = pycdfpp.CDF()
+    cdf.add_variable("int8 variable", values=np.ones((10), dtype=np.int8), attributes={"FILLVAL": [pycdfpp.default_fill_value(pycdfpp.DataType.CDF_INT1)]})
+    cdf.add_variable("tt2000 variable", values=np.ones((10), dtype=np.int64), attributes={"FILLVAL": [pycdfpp.default_fill_value(pycdfpp.DataType.CDF_TIME_TT2000)]})

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,11 +5,11 @@ numpy
 python_dateutil
 matplotlib
 PyYAML
-sphinx!=5.2.0.post0
+sphinx!=5.2.0.post0, <8.0.0
 sphinx-rtd-theme
 argh
 numpydoc
-sphinx-gallery  < 0.11.0
+sphinx-gallery
 nbsphinx
 ipympl
 ipywidgets

--- a/include/cdfpp/cdf-repr.hpp
+++ b/include/cdfpp/cdf-repr.hpp
@@ -78,6 +78,16 @@ inline stream_t& operator<<(stream_t& os, const decltype(cdf::to_time_point(tt20
 template <class stream_t>
 inline stream_t& operator<<(stream_t& os, const epoch& time)
 {
+    if (time.value == -1e31)
+    {
+        os << "9999-12-31T23:59:59.999";
+        return os;
+    }
+    if (time.value == 0)
+    {
+        os << "0000-01-01T00:00:00.000";
+        return os;
+    }
     os << cdf::to_time_point(time);
     return os;
 }
@@ -85,6 +95,16 @@ inline stream_t& operator<<(stream_t& os, const epoch& time)
 template <class stream_t>
 inline stream_t& operator<<(stream_t& os, const epoch16& time)
 {
+    if (time.seconds == -1e31 && time.picoseconds == -1e31)
+    {
+        os << "9999-12-31T23:59:59.999999999";
+        return os;
+    }
+    if (time.seconds == 0 && time.picoseconds == 0)
+    {
+        os << "0000-01-01T00:00:00.000000000000";
+        return os;
+    }
     os << cdf::to_time_point(time);
     return os;
 }

--- a/pycdfpp/__init__.py
+++ b/pycdfpp/__init__.py
@@ -20,7 +20,7 @@ from functools import singledispatch
 from datetime import datetime
 
 import numpy as np
-# from ._pycdfpp import *
+
 from ._pycdfpp import DataType, CompressionType, Majority, Variable, VariableAttribute, Attribute, CDF, tt2000_t, epoch, \
     epoch16, save
 from . import _pycdfpp
@@ -640,3 +640,76 @@ def _(cdf: CDF) -> dict:
             k: to_dict_skeleton(v) for k, v in cdf.items()
         }
     }
+
+
+def default_pad_value(cdf_type: DataType):
+    """
+    Returns a default padding value for the given CDF data type.
+    """
+    if cdf_type in (DataType.CDF_INT1, DataType.CDF_BYTE):
+        return np.int8(-127)
+    if cdf_type == DataType.CDF_UINT1:
+        return np.uint8(254)
+    if cdf_type == DataType.CDF_INT2:
+        return np.int16(-32767)
+    if cdf_type == DataType.CDF_UINT2:
+        return np.uint16(65534)
+    if cdf_type == DataType.CDF_INT4:
+        return np.int32(-2147483647)
+    if cdf_type == DataType.CDF_UINT4:
+        return np.uint32(4294967294)
+    if cdf_type == DataType.CDF_INT8:
+        return np.int64(-9223372036854775807)
+    if cdf_type in (DataType.CDF_REAL4, DataType.CDF_FLOAT):
+        return np.float32(-1e30)
+    if cdf_type in (DataType.CDF_REAL8, DataType.CDF_DOUBLE):
+        return np.float64(-1e30)
+    if cdf_type in (DataType.CDF_CHAR, DataType.CDF_UCHAR):
+        return b'\x00'
+    if cdf_type == DataType.CDF_TIME_TT2000:
+        return tt2000_t(-9223372036854775807)
+    if cdf_type == DataType.CDF_EPOCH:
+        return epoch(0.0)
+    if cdf_type == DataType.CDF_EPOCH16:
+        return epoch16(0.0)
+    return None
+
+
+def default_fill_value(cdf_type: DataType):
+    """
+    Return a default fill value for the given CDF data type.
+
+    Parameters
+    ----------
+    cdf_type : DataType
+        The CDF data type for which to return the default fill value.
+    Returns
+    -------
+    Any
+        The default fill value for the specified CDF data type.
+    """
+    if cdf_type in (DataType.CDF_INT1, DataType.CDF_BYTE):
+        return np.int8(-128)
+    if cdf_type == DataType.CDF_UINT1:
+        return np.uint8(255)
+    if cdf_type == DataType.CDF_INT2:
+        return np.int16(-32768)
+    if cdf_type == DataType.CDF_UINT2:
+        return np.uint16(65535)
+    if cdf_type == DataType.CDF_INT4:
+        return np.int32(-2147483648)
+    if cdf_type == DataType.CDF_UINT4:
+        return np.uint32(4294967295)
+    if cdf_type == DataType.CDF_INT8:
+        return np.int64(-9223372036854775808)
+    if cdf_type in (DataType.CDF_REAL4, DataType.CDF_FLOAT):
+        return np.float32(-1e31)
+    if cdf_type in (DataType.CDF_REAL8, DataType.CDF_DOUBLE):
+        return np.float64(-1e31)
+    if cdf_type == DataType.CDF_TIME_TT2000:
+        return tt2000_t(-9223372036854775808)
+    if cdf_type == DataType.CDF_EPOCH:
+        return epoch(-1e31)
+    if cdf_type == DataType.CDF_EPOCH16:
+        return epoch16(-1e31, - 1e31)
+    return None

--- a/tests/python_saving/test.py
+++ b/tests/python_saving/test.py
@@ -43,6 +43,19 @@ def make_cdf():
                          "numpy_mixed_i16": [np.uint8(1), np.int16(-2), np.int16(3)]
                      }
                      )
+
+    cdf.add_variable("tt2000_special_values",
+                     np.arange(1e18, 11e17, 1e16, dtype=np.int64).astype("datetime64[ns]"),
+                     data_type=pycdfpp.DataType.CDF_TIME_TT2000,
+                     attributes={"FILLVAL": [pycdfpp.default_fill_value(pycdfpp.DataType.CDF_TIME_TT2000)]})
+    cdf.add_variable("epoch_special_values",
+                     np.arange(1e18, 11e17, 1e16, dtype=np.int64).astype("datetime64[ns]"),
+                     data_type=pycdfpp.DataType.CDF_EPOCH,
+                     attributes={"FILLVAL": [pycdfpp.default_fill_value(pycdfpp.DataType.CDF_EPOCH)]})
+    cdf.add_variable("epoch16_special_values",
+                     np.arange(1e18, 11e17, 1e16, dtype=np.int64).astype("datetime64[ns]"),
+                     data_type=pycdfpp.DataType.CDF_EPOCH16,
+                     attributes={"FILLVAL": [pycdfpp.default_fill_value(pycdfpp.DataType.CDF_EPOCH16)]})
     return cdf
 
 
@@ -96,6 +109,15 @@ class PycdfCreateCDFTest(unittest.TestCase):
         self.assertEqual(cdf["test_integer_attributes"].attributes["numpy_i64"].type(), pycdfpp.DataType.CDF_INT8)
         self.assertEqual(cdf["test_integer_attributes"].attributes["numpy_mixed_i16"].type(),
                          pycdfpp.DataType.CDF_INT2)
+
+    def test_default_fill_values(self):
+        # https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#FILLVAL
+        cdf = make_cdf()
+        self.assertEqual(cdf["tt2000_special_values"].attributes["FILLVAL"][0][0],
+                         pycdfpp.tt2000_t(-9223372036854775808))
+        self.assertEqual(str(cdf["tt2000_special_values"].attributes["FILLVAL"][0][0]), '9999-12-31T23:59:59.999999999')
+        self.assertEqual(cdf["epoch_special_values"].attributes["FILLVAL"][0][0], pycdfpp.epoch(-1e31))
+        self.assertEqual(str(cdf["epoch_special_values"].attributes["FILLVAL"][0][0]), '9999-12-31T23:59:59.999')
 
     def test_can_create_CDF_attributes(self):
         cdf = pycdfpp.CDF()


### PR DESCRIPTION
This pull request introduces several changes to enhance the handling of special values in CDF files, improve documentation, and update dependencies. The most important changes include adding support for default fill and pad values for various CDF data types, improving the representation of special values in CDF epochs, and expanding the documentation with an FAQ section.

### Enhancements to CDF Special Values:
* [`include/cdfpp/cdf-repr.hpp`](diffhunk://#diff-5c78c5b1d63dfe57a34cfde82e5861433dff8d72e7a3ba0a0a3c04d148ecee73R81-R107): Added handling for special epoch values (`-1e31` and `0`) and epoch16 values (`-1e31` for seconds and picoseconds, and `0` for both). These values are now represented as specific ISO date strings (e.g., `9999-12-31T23:59:59.999`).
* [`pycdfpp/__init__.py`](diffhunk://#diff-e672e934f2f11c28fc01c3ff390c82a01f18bcc8accc13d951a852cf3ace1a78R643-R715): Introduced `default_fill_value` and `default_pad_value` functions to provide default values for CDF data types, ensuring consistent handling of special values like `FILLVAL` and `Pad values`.

### Updates to Tests:
* [`tests/python_saving/test.py`](diffhunk://#diff-0026baf4c3a302e937f5e8fb58082219513a3e4b6c81fad013678b7e44385848R113-R121): Added tests for special values in CDF variables, verifying that the `FILLVAL` attributes are correctly set for `tt2000`, `epoch`, and `epoch16` data types.
* [`tests/python_saving/test.py`](diffhunk://#diff-0026baf4c3a302e937f5e8fb58082219513a3e4b6c81fad013678b7e44385848R46-R58): Enhanced the `make_cdf` function to include variables with special values for `tt2000`, `epoch`, and `epoch16`, ensuring compatibility with the new default fill values.

### Documentation Improvements:
* [`docs/index.rst`](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R107-R142): Expanded the documentation with an FAQ section that explains how to control integer attribute types using NumPy and how to create special values (`FILLVAL`, `Pad values`, etc.) with `pycdfpp` functions.

### Dependency Updates:
* [`.readthedocs.yaml`](diffhunk://#diff-03efc769b870804394632e45d7885272b44c16939517fb31c9d7c614d2ffae57L15-R15): Updated the Python version to `3.12` for compatibility with newer features.
* [`docs/requirements.txt`](diffhunk://#diff-2c9c11d26b09b8afde329980309d967121543a456e4592c76886a20b5cf56c90L8-R12): Updated the `sphinx-gallery` dependency and restricted `sphinx` to versions below `8.0.0` for compatibility.