### PR TITLE
Fix three bugs in nomap: swap corruption, const_iterator UB, asymmetric equality

### DIFF
--- a/include/cdfpp/nomap.hpp
+++ b/include/cdfpp/nomap.hpp
@@ -67,7 +67,7 @@ struct nomap_node : public std::pair<Key, details::base_type_t<T>>
 
     friend void swap(nomap_node& lhs, nomap_node& rhs)
     {
-        std::swap(lhs.first, rhs.second);
+        std::swap(lhs.first, rhs.first);
         std::swap(lhs.second, rhs.second);
         std::swap(lhs.p_empty, rhs.p_empty);
     }
@@ -116,6 +116,8 @@ struct nomap
 
     inline bool operator==(const nomap& other) const
     {
+        if (size() != other.size())
+            return false;
         for (const auto& node : p_nodes)
         {
             if (!other.count(node.key()))
@@ -229,7 +231,7 @@ struct nomap
         if (position != cend())
         {
             auto next_idx = (position - cbegin());
-            std::swap(*position, p_nodes.back());
+            std::swap(p_nodes[next_idx], p_nodes.back());
             p_nodes.pop_back();
             return cbegin() + next_idx;
         }

--- a/tests/nomap/main.cpp
+++ b/tests/nomap/main.cpp
@@ -18,6 +18,77 @@
 #include "tests_config.hpp"
 
 
+SCENARIO("nomap_node swap preserves keys and values", "[CDF][nomap]")
+{
+    GIVEN("two nomap_nodes with distinct keys and values")
+    {
+        nomap_node<int, int> a(10, 1);
+        nomap_node<int, int> b(20, 2);
+
+        WHEN("they are swapped")
+        {
+            swap(a, b);
+
+            THEN("keys are exchanged correctly")
+            {
+                REQUIRE(a.first == 20);
+                REQUIRE(b.first == 10);
+            }
+            THEN("values are exchanged correctly")
+            {
+                REQUIRE(a.second == 2);
+                REQUIRE(b.second == 1);
+            }
+        }
+    }
+}
+
+SCENARIO("nomap erase by const_iterator works correctly", "[CDF][nomap]")
+{
+    GIVEN("a nomap with three entries")
+    {
+        nomap<std::string, int> map;
+        map["a"] = 1;
+        map["b"] = 2;
+        map["c"] = 3;
+
+        WHEN("erasing via const_iterator")
+        {
+            auto cit = map.cbegin();
+            auto erased_key = cit->first;
+            map.erase(cit);
+
+            THEN("size decreases")
+            {
+                REQUIRE(map.size() == 2);
+            }
+            THEN("erased key is no longer found")
+            {
+                REQUIRE(map.find(erased_key) == map.end());
+            }
+        }
+    }
+}
+
+SCENARIO("nomap operator== is symmetric", "[CDF][nomap]")
+{
+    GIVEN("two maps where one has an extra key")
+    {
+        nomap<std::string, int> small_map;
+        small_map["a"] = 1;
+
+        nomap<std::string, int> big_map;
+        big_map["a"] = 1;
+        big_map["b"] = 2;
+
+        THEN("they must not be equal in either direction")
+        {
+            REQUIRE_FALSE(small_map == big_map);
+            REQUIRE_FALSE(big_map == small_map);
+        }
+    }
+}
+
 SCENARIO("nomap", "[CDF]")
 {
     GIVEN("a map")

--- a/tests/python_saving/test.py
+++ b/tests/python_saving/test.py
@@ -70,7 +70,7 @@ class PycdfCreateCDFTest(unittest.TestCase):
         self.assertEqual(pycdfpp.CDF(), pycdfpp.CDF())
 
     def test_compare_differents_cdfs(self):
-        self.assertEqual(make_cdf(), pycdfpp.CDF())
+        self.assertNotEqual(make_cdf(), pycdfpp.CDF())
 
     def test_in_memory_save_load_empty_CDF_object(self):
         cdf = pycdfpp.CDF()


### PR DESCRIPTION
This pull request improves the correctness and robustness of the `nomap` and `nomap_node` classes in the `cdfpp` library, and adds new tests to verify these behaviors. The main changes include fixing swap logic for `nomap_node`, strengthening the equality operator for `nomap`, correcting the erase operation, and introducing targeted unit tests.

**Bug fixes and correctness improvements:**

* Fixed the swap implementation in `nomap_node` to correctly exchange keys between nodes, preventing erroneous value swaps.
* Improved the `operator==` for `nomap` by adding a size check, ensuring that maps with different sizes are never considered equal.
* Corrected the erase operation in `nomap` to use the proper index for swapping before removal, ensuring iterator validity and correct element removal.

**Testing enhancements:**

* Added unit tests in `tests/nomap/main.cpp` to verify `nomap_node` swap behavior, `nomap` erase via const_iterator, and the symmetry of `nomap` equality operator.