### PR TITLE
Fix nomap getitem and docs improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+CDFpp is a C++20 implementation of NASA's CDF (Common Data Format) from scratch (not a wrapper). It provides multi-threaded support, a modern C++ API, and Python bindings (`pycdfpp`) via pybind11.
+
+## Build Commands
+
+```bash
+# Configure and build (C++ only)
+meson setup build
+ninja -C build
+
+# With tests enabled
+meson setup -Dwith_tests=true build
+ninja -C build
+
+# Run all tests
+ninja test -C build
+
+# Run a single C++ test (Catch2)
+./build/tests/simple_open/test-simple_open
+
+# Run a single Python test
+python3 tests/python_loading/test.py
+
+# Build Python wheel
+python -m build .
+
+# Benchmarks
+meson setup -Dwith_benchmarks=true build
+ninja benchmark -C build
+```
+
+Key meson options: `-Duse_libdeflate=true` (default, faster gzip), `-Dwith_experimental_zstd=true`, `-Ddisable_python_wrapper=true`.
+
+## Architecture
+
+**Header-only C++ library** in `include/cdfpp/`:
+- `cdf.hpp` — Root container: holds `variables` and `attributes` maps, file majority, compression type
+- `variable.hpp` — Scientific data variable with shape, type, and lazy-loadable values
+- `attribute.hpp` — Metadata key-value storage (vector of variant `data_t` values)
+- `cdf-io/` — All I/O: `loading/` parses CDF binary format, `saving/` serializes it. Entry points: `cdf::io::load()`, `cdf::io::save()`
+- `cdf-io/compression.hpp` / `decompression.hpp` — GZip (zlib/libdeflate), RLE, experimental Zstd
+- `chrono/` — SIMD-optimized time conversions (CDF_EPOCH, EPOCH16, TT2000) with leap second handling
+
+**Python bindings** in `pycdfpp/`:
+- `pycdfpp.cpp` — pybind11 module definition (`_pycdfpp`)
+- Per-type wrappers: `variable.hpp`, `attribute.hpp`, `cdf.hpp`, `chrono.hpp`
+- GIL-free operations (`py::mod_gil_not_used()`)
+
+**SIMD** in `simd/` and `src/arch/x86/`: runtime dispatch via xsimd for AVX512/AVX2/SSE2 chrono conversions.
+
+**Custom containers**: `cdf-map.hpp` / `nomap.hpp` — ordered map used for variables and attributes (controlled by `-Duse_nomap`).
+
+## Tests
+
+- **C++**: Catch2 v3, one directory per test under `tests/` (e.g. `simple_open/`, `chrono/`, `records_loading/`)
+- **Python**: unittest + ddt, under `tests/python_*/`
+- **Test data**: `tests/resources/` with real CDF files; `tests/resources/make_cdf.py` generates additional test data
+
+## Code Style
+
+- C++20 standard
+- `.clang-format`: WebKit-based, 100 column limit, 4-space indent, Allman braces
+- Variables/attributes must have non-empty names (enforced at creation)
+
+## Known Limitations
+
+**Python bindings: nomap reference invalidation.** The default `nomap` container is backed by `std::vector`. Python wrappers returned by `__getitem__` hold raw pointers into this vector. Any insertion or deletion (e.g. `add_variable`, `add_attribute`, `remove_variable`) can reallocate the vector and invalidate those pointers, causing segfaults. Do not keep references to variables or attributes while mutating the same map. For example:
+
+```python
+# UNSAFE — attr may become a dangling pointer after add_attribute
+attr = cdf["var"].attributes["DEPEND_0"]
+cdf["var"].add_attribute("NEW", "value")  # may reallocate
+attr.value  # potential segfault
+
+# SAFE — re-fetch after mutation
+cdf["var"].add_attribute("NEW", "value")
+attr = cdf["var"].attributes["DEPEND_0"]
+```
+
+## Dependencies (as meson subprojects)
+
+pybind11, fmt, Catch2, xsimd, libdeflate, hedley. Python ≥3.9, numpy, pyyaml at runtime.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub License](https://img.shields.io/github/license/SciQLop/CDFpp)](https://mit-license.org/)
 [![Documentation Status](https://readthedocs.org/projects/pycdfpp/badge/?version=latest)](https://pycdfpp.readthedocs.io/en/latest/?badge=latest)
-[![CPP17](https://img.shields.io/badge/Language-C++17-blue.svg)]()
+[![CPP20](https://img.shields.io/badge/Language-C++20-blue.svg)]()
 [![PyPi](https://img.shields.io/pypi/v/pycdfpp.svg)](https://pypi.python.org/pypi/pycdfpp)
 [![Coverage](https://codecov.io/gh/SciQLop/CDFpp/coverage.svg?branch=main)](https://codecov.io/gh/SciQLop/CDFpp/branch/main)
 [![Discover on MyBinder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/SciQLop/CDFpp/main?labpath=examples/notebooks)
@@ -95,7 +95,7 @@ ninja
 sudo ninja install
 ```
 
-Or if youl want to build a Python wheel:
+Or if you want to build a Python wheel:
 
 ```bash
 python -m build . 
@@ -186,7 +186,7 @@ pycdfpp.save(cdf, "some_cdf.cdf")
 
 ## C++
 ```cpp
-#include "cdf-io/cdf-io.hpp"
+#include "cdfpp/cdf-io/cdf-io.hpp"
 #include <iostream>
 
 std::ostream& operator<<(std::ostream& os, const cdf::Variable::shape_t& shape)
@@ -222,5 +222,6 @@ int main(int argc, char** argv)
 }
 ```
 
-## caveats
-- NRV variables shape, in order to expose a consistent shape, PyCDFpp exposes the reccord count as first dimension and thus its value will be either 0 or 1 (0 mean empty variable).
+## Caveats
+- **NRV variables shape**: in order to expose a consistent shape, PyCDFpp exposes the record count as first dimension and thus its value will be either 0 or 1 (0 means empty variable).
+- **Reference invalidation**: PyCDFpp returns references into C++ data structures. Adding or removing variables/attributes may invalidate previously obtained references. Always re-fetch after mutation (see [documentation](https://pycdfpp.readthedocs.io/en/latest/) for details).

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -57,7 +57,7 @@ If you are proposing a feature:
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `SPEASY` for local development.
+Ready to contribute? Here's how to set up `PyCDFpp` for local development.
 
 1. Fork the `PyCDFpp` repo on GitHub.
 2. Clone your fork locally::
@@ -87,7 +87,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python from 3.8 to 3.11. Check
+3. The pull request should work for Python 3.9 and above. Check
    https://github.com/SciQLop/cdfpp/actions
    and make sure that the tests pass for all supported Python versions.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,6 +87,28 @@ Datetimes handling:
     # note that using datetime64 is ~100x faster than datetime (~2ns/element on an average laptop)
 
 
+Lazy loading
+------------
+
+By default, ``pycdfpp.load`` uses lazy loading: variable metadata (name, shape, type,
+attributes) is read immediately, but variable **values** are only loaded from disk when
+first accessed. This makes opening large CDF files very fast when you only need a
+subset of variables.
+
+.. code-block:: python
+
+    import pycdfpp
+
+    # Lazy loading (default) — fast open, values loaded on demand
+    cdf = pycdfpp.load("large_file.cdf")
+    cdf["Epoch"].values_loaded  # False — not yet read from disk
+    data = cdf["Epoch"].values  # triggers the actual read
+    cdf["Epoch"].values_loaded  # True
+
+    # Eager loading — all values read upfront
+    cdf = pycdfpp.load("large_file.cdf", lazy_load=False)
+
+
 Writing CDF files
 -----------------
 
@@ -100,9 +122,127 @@ Creating a basic CDF file:
 
     cdf = pycdfpp.CDF()
     cdf.add_attribute("some attribute", [[1,2,3], [datetime(2018,1,1), datetime(2018,1,2)], "hello\nworld"])
-    cdf.add_variable(f"some variable", values=np.ones((10),dtype=np.float64))
+    cdf.add_variable("some variable", values=np.ones((10),dtype=np.float64))
     pycdfpp.save(cdf, "some_cdf.cdf")
 
+
+Working with variable attributes
+---------------------------------
+
+Variables can have their own attributes (distinct from global CDF attributes).
+These are commonly used for ISTP metadata such as ``DEPEND_0``, ``FILLVAL``, ``UNITS``, etc.
+
+.. code-block:: python
+
+    import pycdfpp
+    import numpy as np
+
+    cdf = pycdfpp.CDF()
+    var = cdf.add_variable("Flux", values=np.ones((100, 3), dtype=np.float64))
+
+    # Add attributes to a variable
+    var.add_attribute("UNITS", "cm^-2 s^-1")
+    var.add_attribute("DEPEND_0", "Epoch")
+    var.add_attribute("FILLVAL", [-1e31])
+
+    # Read variable attributes
+    print(var.attributes["UNITS"].value)      # "cm^-2 s^-1"
+    print(list(var.attributes))               # ["UNITS", "DEPEND_0", "FILLVAL"]
+
+    # Modify an existing attribute value
+    var.attributes["UNITS"].set_value("m^-2 s^-1")
+
+
+Modifying variables
+-------------------
+
+You can update the values of an existing variable using ``set_values``:
+
+.. code-block:: python
+
+    import pycdfpp
+    import numpy as np
+
+    cdf = pycdfpp.CDF()
+    var = cdf.add_variable("data", values=np.zeros(10, dtype=np.float64))
+
+    # Replace values (must match shape and type, unless force=True)
+    var.set_values(np.ones(10, dtype=np.float64))
+
+    # Force replacement with different shape or type
+    var.set_values(np.arange(20, dtype=np.int32), force=True)
+
+
+Using compression
+-----------------
+
+Variables and entire CDF files can use GZip or RLE compression:
+
+.. code-block:: python
+
+    import pycdfpp
+    import numpy as np
+
+    cdf = pycdfpp.CDF()
+
+    # Per-variable compression
+    cdf.add_variable("compressed_var",
+                     values=np.arange(1000, dtype=np.float64),
+                     compression=pycdfpp.CompressionType.gzip_compression)
+
+    # Whole-file compression
+    cdf.compression = pycdfpp.CompressionType.gzip_compression
+
+    pycdfpp.save(cdf, "compressed.cdf")
+
+
+Filtering CDF files
+-------------------
+
+Use ``CDF.filter`` to create a copy containing only the variables and attributes
+you need:
+
+.. code-block:: python
+
+    import pycdfpp
+
+    cdf = pycdfpp.load("large_file.cdf")
+
+    # Keep only specific variables by name
+    filtered = cdf.filter(variables=["Epoch", "Flux"])
+
+    # Keep variables matching a regex pattern
+    filtered = cdf.filter(variables="tha_fg.*")
+
+    # Keep variables matching a callable
+    filtered = cdf.filter(variables=lambda v: v.type == pycdfpp.DataType.CDF_DOUBLE)
+
+    # Keep specific global attributes
+    filtered = cdf.filter(variables=["Epoch"], attributes=["Project", "Source_name"])
+
+    # Filter in-place (modifies the original)
+    cdf.filter(variables=["Epoch"], inplace=True)
+
+
+Exporting to dictionary
+------------------------
+
+Use ``pycdfpp.to_dict_skeleton`` to export the structure of a CDF, variable, or attribute
+as a plain dictionary (useful for JSON serialization or inspection):
+
+.. code-block:: python
+
+    import pycdfpp
+    import json
+
+    cdf = pycdfpp.load("some_cdf.cdf")
+
+    # Export full CDF structure (without variable data)
+    skeleton = pycdfpp.to_dict_skeleton(cdf)
+    print(json.dumps(skeleton, indent=2, default=str))
+
+    # Export a single variable's metadata
+    var_info = pycdfpp.to_dict_skeleton(cdf["some_var"])
 
 
 FAQ
@@ -127,7 +267,35 @@ Use numpy types to control the type of integer attributes:
     # or:
     cdf.add_attribute("int8 attribute2", [[np.int8(1)]])
 
-How to make special values (FILLVAL, Pad valuse, etc.)?
+Why do I get a segfault when accessing attributes after modifying a CDF?
+------------------------------------------------------------------------
+
+PyCDFpp returns lightweight references into the underlying C++ data structures.
+Adding or removing variables or attributes may reallocate internal storage, which
+invalidates any previously obtained reference. Always re-fetch references after
+mutating the CDF:
+
+.. code-block:: python
+
+    import pycdfpp
+    import numpy as np
+
+    cdf = pycdfpp.CDF()
+    cdf.add_variable("var1", values=np.ones(10))
+    var1 = cdf["var1"]
+
+    # UNSAFE — var1 may be invalidated by the next add_variable call
+    cdf.add_variable("var2", values=np.zeros(5))
+    # var1.values  # may segfault!
+
+    # SAFE — re-fetch after mutation
+    var1 = cdf["var1"]
+    var1.values  # ok
+
+The same applies to attribute references: do not hold onto a reference returned by
+``var.attributes["name"]`` while adding or removing attributes on the same variable.
+
+How to make special values (FILLVAL, Pad values, etc.)?
 -------------------------------------------------------
 
 Use the `pycdfpp.default_fill_value` and `pycdfpp.default_pad_value` functions to create Fill or Pad values depending on the CDF type:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,7 +42,7 @@ Or download the `tarball`_:
 
     $ curl  -OL https://github.com/SciQLop/cdfpp/tarball/main
 
-Once you have a copy of the source, you can install it with (a working C++17 compiler is needed):
+Once you have a copy of the source, you can install it with (a working C++20 compiler is needed):
 
 .. code-block:: console
 

--- a/pycdfpp/pycdfpp.cpp
+++ b/pycdfpp/pycdfpp.cpp
@@ -68,7 +68,14 @@ auto def_cdf_map(T3& mod, const char* name)
     return py::class_<cdf_map<T1, T2>>(mod, name)
         .def("__repr__", __repr__<cdf_map<T1, T2>>)
         .def(
-            "__getitem__", [](cdf_map<T1, T2>& m, const std::string& key) -> T2& { return m[key]; },
+            "__getitem__",
+            [](cdf_map<T1, T2>& m, const std::string& key) -> T2&
+            {
+                auto it = m.find(key);
+                if (it == m.end())
+                    throw py::key_error(key);
+                return it->second;
+            },
             py::return_value_policy::reference_internal)
         .def("__contains__",
             [](const cdf_map<T1, T2>& m, std::string& key) { return m.count(key) > 0; })


### PR DESCRIPTION
This pull request introduces significant improvements to documentation, error handling, and user guidance for both the C++ and Python APIs of the project. The most important changes include the addition of a comprehensive guide for Claude Code, expanded Python documentation covering advanced features, improved reference invalidation warnings, and enhanced error handling in Python bindings. There are also updates to build instructions and code style references to reflect the transition to C++20.

**Documentation and User Guidance**

* Added `CLAUDE.md`, a detailed guide for Claude Code contributors, covering project architecture, build commands, code style, known limitations (especially Python reference invalidation), and dependencies.
* Expanded `docs/index.rst` with new sections on lazy loading, variable attributes, modifying variables, compression, filtering, and exporting CDF structures, providing practical usage examples for advanced features. [[1]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R90-R111) [[2]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L103-R246)
* Added explicit warnings and FAQ entries about reference invalidation in Python, instructing users to re-fetch references after mutations to avoid segfaults.
* Updated `README.md` caveats section to highlight reference invalidation risks and best practices.

**Build and Installation Instructions**

* Updated build instructions to reference C++20 (instead of C++17) in both `README.md` and `docs/installation.rst`, ensuring clarity about compiler requirements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-d9b149498982c0663c3b7170398773361ed5678f1a627e9c2fd8d2c955c563dbL45-R45)
* Fixed minor typos and clarified Python wheel build instructions in `README.md`.

**Python API and Error Handling**

* Improved error handling in Python bindings: `cdf_map.__getitem__` now raises `py::key_error` when a key is missing, instead of returning a potentially invalid reference.

**Project Naming and Supported Versions**

* Updated project references in `docs/contributing.rst` from `SPEASY` to `PyCDFpp` and clarified supported Python versions (3.9+). [[1]](diffhunk://#diff-e052d37005ef738791e533f325afeb1f194d5d2c18e5cb0cd992ca56097baba0L60-R60) [[2]](diffhunk://#diff-e052d37005ef738791e533f325afeb1f194d5d2c18e5cb0cd992ca56097baba0L90-R90)

**Code Style and API Consistency**

* Updated code samples and file includes to use the correct `cdfpp/cdf-io/cdf-io.hpp` path and clarified C++20 usage.

These changes collectively improve developer onboarding, clarify advanced usage and limitations, and make the Python API safer and more user-friendly.