### PR TITLE
Fix pre-release bugs: RLE, TT2000, nomap, record_size

### DIFF
--- a/benchmarks/meson.build
+++ b/benchmarks/meson.build
@@ -1,5 +1,5 @@
 google_benchmarks_dep = dependency('benchmark', required : true)
-foreach bench:['file_reader', 'chrono']
+foreach bench:['file_reader', 'chrono', 'rle']
     exe = executable('benchmark-'+bench, bench+'/main.cpp',
                     dependencies:[google_benchmarks_dep, cdfpp_dep],
                     install: false

--- a/benchmarks/rle/main.cpp
+++ b/benchmarks/rle/main.cpp
@@ -1,0 +1,61 @@
+#include <benchmark/benchmark.h>
+#include <cdfpp/cdf-io/rle.hpp>
+#include <cdfpp/no_init_vector.hpp>
+#include <cstring>
+#include <random>
+
+no_init_vector<char> make_rle_friendly_data(std::size_t size, double zero_fraction)
+{
+    no_init_vector<char> data(size);
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    std::uniform_int_distribution<int> byte_dist(1, 127);
+    for (auto& b : data)
+        b = (dist(rng) < zero_fraction) ? 0 : static_cast<char>(byte_dist(rng));
+    return data;
+}
+
+static void BM_rle_deflate(benchmark::State& state)
+{
+    auto data = make_rle_friendly_data(state.range(0), 0.5);
+    for (auto _ : state)
+    {
+        auto result = cdf::io::rle::deflate(data);
+        benchmark::DoNotOptimize(result);
+    }
+    state.counters["bytes_per_second"]
+        = benchmark::Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate);
+}
+BENCHMARK(BM_rle_deflate)->RangeMultiplier(4)->Range(1024, 1024 * 1024)->Complexity();
+
+static void BM_rle_inflate(benchmark::State& state)
+{
+    auto data = make_rle_friendly_data(state.range(0), 0.5);
+    auto compressed = cdf::io::rle::deflate(data);
+    no_init_vector<char> output(data.size());
+    for (auto _ : state)
+    {
+        cdf::io::rle::inflate(compressed, output.data(), output.size());
+        benchmark::DoNotOptimize(output);
+    }
+    state.counters["bytes_per_second"]
+        = benchmark::Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate);
+}
+BENCHMARK(BM_rle_inflate)->RangeMultiplier(4)->Range(1024, 1024 * 1024)->Complexity();
+
+static void BM_rle_roundtrip(benchmark::State& state)
+{
+    auto data = make_rle_friendly_data(state.range(0), 0.5);
+    no_init_vector<char> output(data.size());
+    for (auto _ : state)
+    {
+        auto compressed = cdf::io::rle::deflate(data);
+        cdf::io::rle::inflate(compressed, output.data(), output.size());
+        benchmark::DoNotOptimize(output);
+    }
+    state.counters["bytes_per_second"]
+        = benchmark::Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate);
+}
+BENCHMARK(BM_rle_roundtrip)->RangeMultiplier(4)->Range(1024, 1024 * 1024)->Complexity();
+
+BENCHMARK_MAIN();

--- a/include/cdfpp/cdf-io/loading/variable.hpp
+++ b/include/cdfpp/cdf-io/loading/variable.hpp
@@ -111,7 +111,7 @@ namespace
     template <typename cdf_version_tag_t, typename buffer_t>
     inline void load_vvr_data(buffer_t& stream, std::size_t offset,
         const cdf_VVR_t<cdf_version_tag_t>& vvr, const std::size_t vvr_records_count,
-        const uint32_t record_size, std::size_t& pos, char* data, std::size_t data_len)
+        const std::size_t record_size, std::size_t& pos, char* data, std::size_t data_len)
     {
         std::size_t vvr_data_size
             = std::min(static_cast<std::size_t>(vvr_records_count * record_size),
@@ -131,7 +131,7 @@ namespace
 
     template <typename cdf_version_tag_t, typename stream_t>
     void load_var_data(stream_t& stream, char* data, std::size_t data_len, std::size_t& pos,
-        const cdf_VXR_t<cdf_version_tag_t>& vxr, uint32_t record_size,
+        const cdf_VXR_t<cdf_version_tag_t>& vxr, std::size_t record_size,
         const cdf_compression_type compression_type)
     {
         for (auto i = 0UL; i < vxr.NusedEntries; i++)
@@ -179,7 +179,7 @@ namespace
     }
 
     template <typename VDR_t, typename stream_t>
-    data_t load_var_data(stream_t& stream, const VDR_t& vdr, const uint32_t record_size,
+    data_t load_var_data(stream_t& stream, const VDR_t& vdr, const std::size_t record_size,
         const uint32_t record_count, const cdf_compression_type compression_type)
     {
         data_t data = new_data_container(
@@ -216,7 +216,7 @@ namespace
     struct defered_variable_loader
     {
         defered_variable_loader(stream_t stream, cdf_encoding encoding, VDR_t vdr,
-            uint32_t record_count, uint32_t record_size, cdf_compression_type compression)
+            uint32_t record_count, std::size_t record_size, cdf_compression_type compression)
                 : p_stream { stream }
                 , p_encoding { encoding }
                 , p_vdr { vdr }
@@ -239,7 +239,7 @@ namespace
         cdf_encoding p_encoding;
         VDR_t p_vdr;
         uint32_t p_record_count;
-        uint32_t p_record_size;
+        std::size_t p_record_size;
         cdf_compression_type p_compression;
     };
 
@@ -252,7 +252,7 @@ namespace
                 const auto& [offset, vdr] = blk;
                 {
                     auto shape = get_variable_dimensions<type>(vdr, context);
-                    const uint32_t record_size = var_record_size(shape, vdr.DataType);
+                    const std::size_t record_size = var_record_size(shape, vdr.DataType);
                     const auto is_nrv = common::is_nrv(vdr);
                     const auto compression_type = [&, &stream = context, &vdr = vdr]()
                     {
@@ -271,7 +271,7 @@ namespace
                             return 1;
                         else
                         {
-                            return MaxRec + 1;
+                            return static_cast<uint32_t>(MaxRec) + 1U;
                         }
                     }();
                     /*if ((vdr.DataType != CDF_Types::CDF_CHAR

--- a/include/cdfpp/cdf-io/rle.hpp
+++ b/include/cdfpp/cdf-io/rle.hpp
@@ -40,6 +40,8 @@ namespace _internal
 template <typename T>
 inline std::size_t inflate(const T& input, char* output, const std::size_t output_size)
 {
+    if (output_size == 0 || output == nullptr)
+        return 0;
     auto output_cursor = output;
     const auto output_end = output + output_size;
     auto input_cursor = std::cbegin(input);

--- a/include/cdfpp/cdf-io/rle.hpp
+++ b/include/cdfpp/cdf-io/rle.hpp
@@ -38,18 +38,23 @@ namespace _internal
 }
 
 template <typename T>
-inline std::size_t inflate(const T& input, char* output, const std::size_t)
+inline std::size_t inflate(const T& input, char* output, const std::size_t output_size)
 {
     auto output_cursor = output;
+    const auto output_end = output + output_size;
     auto input_cursor = std::cbegin(input);
-    while (input_cursor != std::cend(input))
+    while (input_cursor != std::cend(input) && output_cursor < output_end)
     {
         auto value = *input_cursor;
         if (value == 0)
         {
             input_cursor++;
-            std::size_t count = static_cast<unsigned char>(*input_cursor) + 1;
-            std::generate_n(output_cursor, count, []() constexpr { return 0; });
+            if (input_cursor == std::cend(input))
+                break;
+            std::size_t count
+                = std::min(static_cast<std::size_t>(static_cast<unsigned char>(*input_cursor) + 1),
+                    static_cast<std::size_t>(output_end - output_cursor));
+            std::fill_n(output_cursor, count, char { 0 });
             output_cursor += count;
         }
         else

--- a/include/cdfpp/chrono/cdf-chrono-impl.hpp
+++ b/include/cdfpp/chrono/cdf-chrono-impl.hpp
@@ -98,7 +98,8 @@ inline auto _leap_second(const tt2000_t& ep, std::size_t leap_index_hint)
         {
             ++leap_index_hint;
         }
-        return std::tuple { leap_seconds::leap_seconds_tt2000_reverse[leap_index_hint].second,
+        return std::tuple { static_cast<int64_t>(
+                                 leap_seconds::leap_seconds_tt2000_reverse[leap_index_hint].second),
             leap_index_hint };
     }
     else
@@ -110,7 +111,8 @@ inline auto _leap_second(const tt2000_t& ep, std::size_t leap_index_hint)
         }
         if (ep.nseconds < leap_seconds::leap_seconds_tt2000_reverse[0].first)
             return std::tuple { int64_t { 0 }, std::size_t { 0 } };
-        return std::tuple { leap_seconds::leap_seconds_tt2000_reverse[leap_index_hint].second,
+        return std::tuple { static_cast<int64_t>(
+                                leap_seconds::leap_seconds_tt2000_reverse[leap_index_hint].second),
             leap_index_hint };
     }
 }

--- a/include/cdfpp/chrono/cdf-chrono-impl.hpp
+++ b/include/cdfpp/chrono/cdf-chrono-impl.hpp
@@ -70,7 +70,7 @@ inline int64_t leap_second(int64_t ns_from_1970)
 
 inline int64_t leap_second(const tt2000_t& ep)
 {
-    if (ep.nseconds > leap_seconds::leap_seconds_tt2000_reverse.front().first)
+    if (ep.nseconds >= leap_seconds::leap_seconds_tt2000_reverse.front().first)
     {
         if (ep.nseconds < leap_seconds::leap_seconds_tt2000_reverse.back().first)
         {
@@ -108,6 +108,8 @@ inline auto _leap_second(const tt2000_t& ep, std::size_t leap_index_hint)
         {
             --leap_index_hint;
         }
+        if (ep.nseconds < leap_seconds::leap_seconds_tt2000_reverse[0].first)
+            return std::tuple { int64_t { 0 }, std::size_t { 0 } };
         return std::tuple { leap_seconds::leap_seconds_tt2000_reverse[leap_index_hint].second,
             leap_index_hint };
     }

--- a/include/cdfpp/nomap.hpp
+++ b/include/cdfpp/nomap.hpp
@@ -242,14 +242,15 @@ struct nomap
     {
         if (first != cend() and first <= last)
         {
-            auto next_idx = (first - cbegin());
-            auto count = last - first;
-            while (count--)
+            auto start_idx = static_cast<std::size_t>(first - cbegin());
+            auto count = static_cast<std::size_t>(last - first);
+            auto new_size = p_nodes.size() - count;
+            for (std::size_t i = 0; i < count && start_idx + i < new_size; ++i)
             {
-                std::swap(p_nodes[next_idx], p_nodes.back());
-                p_nodes.pop_back();
+                p_nodes[start_idx + i] = std::move(p_nodes[new_size + i]);
             }
-            return begin() + next_idx;
+            p_nodes.resize(new_size);
+            return begin() + start_idx;
         }
         return end();
     }

--- a/include/cdfpp/nomap.hpp
+++ b/include/cdfpp/nomap.hpp
@@ -240,7 +240,7 @@ struct nomap
 
     inline iterator erase(const_iterator first, const_iterator last)
     {
-        if (first != cend() and last != cend() and first <= last)
+        if (first != cend() and first <= last)
         {
             auto next_idx = (first - cbegin());
             auto count = last - first;
@@ -249,7 +249,7 @@ struct nomap
                 std::swap(p_nodes[next_idx], p_nodes.back());
                 p_nodes.pop_back();
             }
-            return cbegin() + next_idx;
+            return begin() + next_idx;
         }
         return end();
     }

--- a/include/cdfpp/vectorized/cdf-chrono-impl.hpp
+++ b/include/cdfpp/vectorized/cdf-chrono-impl.hpp
@@ -313,6 +313,8 @@ struct _to_ns_from_1970_tt2000_t
                            leap_seconds::leap_seconds_tt2000_reverse[leap_index].first));
                 leap_index--;
             }
+            // Values before all table entries still need one final correction
+            offset = xsimd::select(needs_correction, offset + one_sec, offset);
             store<Arch, output_align_mode>(tt2000_batch + offset, &output[i]);
         }
         // sfence<Arch>();

--- a/pycdfpp/data_types.hpp
+++ b/pycdfpp/data_types.hpp
@@ -190,6 +190,10 @@ struct analyze_context
 {
     // CDF format only supports up to signed 64 bits integers and unsigned 32 bits integers
     int64_t val = PyLong_AsLongLong(const_cast<PyObject*>(value));
+    if (val == -1 && PyErr_Occurred())
+    {
+        throw py::error_already_set();
+    }
     return { BestTypeId::Int64, val, val, 0 };
 }
 

--- a/tests/chrono/main.cpp
+++ b/tests/chrono/main.cpp
@@ -27,6 +27,17 @@ TEST_CASE("Leap Seconds", "")
             REQUIRE(cdf::_impl::leap_second_branchless(item.first + 1000000000) == item.second);
         }
     }
+    SECTION("tt2000_t leap_second at exact boundary")
+    {
+        // The first entry in the reverse table corresponds to Jan 1, 1972
+        auto first_entry = leap_seconds_tt2000_reverse.front();
+        REQUIRE(cdf::_impl::leap_second(cdf::tt2000_t { first_entry.first }) == first_entry.second);
+    }
+    SECTION("tt2000_t leap_second returns 0 for pre-1972")
+    {
+        // Any TT2000 value before Jan 1, 1972 should have 0 leap seconds
+        REQUIRE(cdf::_impl::leap_second(cdf::tt2000_t { -1000000000000000000 }) == 0);
+    }
 }
 
 
@@ -65,6 +76,36 @@ TEST_CASE("To ns from 1970", "")
             }
         }
     }
+    SECTION("Scalar pre-1960 (no TAI-UTC offset)")
+    {
+        for (const auto& item : test_values)
+        {
+            // Before ~1960, TAI==UTC so tt2000 + offset == unix_epoch * 1e9 exactly.
+            // NASA CDF starts applying pre-leap-second TAI-UTC corrections around 1960.
+            if (item.unix_epoch < -320112000)
+            {
+                int64_t output = 0;
+                cdf::_impl::scalar_to_ns_from_1970({&item.tt2000_epoch, 1}, &output);
+                int64_t expected = item.unix_epoch * 1'000'000'000LL;
+                REQUIRE(output == expected);
+            }
+        }
+    }
+    SECTION("Scalar 1960-1972 (rubber seconds era, no gross error)")
+    {
+        for (const auto& item : test_values)
+        {
+            // Between ~1960-1972, fractional TAI-UTC offsets exist that we don't model.
+            // Just verify there's no 10-second gross error from the old leap_second bug.
+            if (item.unix_epoch >= -320112000 && item.unix_epoch < 68688000)
+            {
+                int64_t output = 0;
+                cdf::_impl::scalar_to_ns_from_1970({&item.tt2000_epoch, 1}, &output);
+                int64_t expected = item.unix_epoch * 1'000'000'000LL;
+                REQUIRE(std::abs(output - expected) < 11'000'000'000LL);
+            }
+        }
+    }
     SECTION("Vectorized against scalar")
     {
         std::vector<cdf::tt2000_t> inputs(1024);
@@ -79,6 +120,35 @@ TEST_CASE("To ns from 1970", "")
         for (std::size_t i = 0; i < outputs.size(); ++i)
         {
             REQUIRE(outputs[i] == expected_outputs[i]);
+        }
+    }
+    SECTION("Vectorized pre-1972 matches scalar")
+    {
+        for (const auto& item : test_values)
+        {
+            if (item.unix_epoch < 68688000)
+            {
+                int64_t scalar_output = 0;
+                int64_t vectorized_output = 0;
+                cdf::_impl::scalar_to_ns_from_1970({&item.tt2000_epoch, 1}, &scalar_output);
+                cdf::to_ns_from_1970(
+                    std::span<const cdf::tt2000_t> { &item.tt2000_epoch, 1 }, &vectorized_output);
+                REQUIRE(scalar_output == vectorized_output);
+            }
+        }
+    }
+    SECTION("Vectorized pre-1960 exact")
+    {
+        for (const auto& item : test_values)
+        {
+            if (item.unix_epoch < -320112000)
+            {
+                int64_t output = 0;
+                cdf::to_ns_from_1970(
+                    std::span<const cdf::tt2000_t> { &item.tt2000_epoch, 1 }, &output);
+                int64_t expected = item.unix_epoch * 1'000'000'000LL;
+                REQUIRE(output == expected);
+            }
         }
     }
 }

--- a/tests/nomap/main.cpp
+++ b/tests/nomap/main.cpp
@@ -89,6 +89,38 @@ SCENARIO("nomap operator== is symmetric", "[CDF][nomap]")
     }
 }
 
+SCENARIO("nomap erase(begin, end) clears the map", "[CDF][nomap]")
+{
+    GIVEN("a nomap with three entries")
+    {
+        nomap<std::string, int> map;
+        map["a"] = 1;
+        map["b"] = 2;
+        map["c"] = 3;
+
+        WHEN("erasing the full range erase(begin(), end())")
+        {
+            map.erase(map.cbegin(), map.cend());
+
+            THEN("the map is empty")
+            {
+                REQUIRE(map.size() == 0);
+                REQUIRE(map.empty());
+            }
+        }
+
+        WHEN("erasing a partial range ending at end()")
+        {
+            map.erase(map.cbegin() + 1, map.cend());
+
+            THEN("only the first element remains")
+            {
+                REQUIRE(map.size() == 1);
+            }
+        }
+    }
+}
+
 SCENARIO("nomap", "[CDF]")
 {
     GIVEN("a map")

--- a/tests/nomap/main.cpp
+++ b/tests/nomap/main.cpp
@@ -121,6 +121,43 @@ SCENARIO("nomap erase(begin, end) clears the map", "[CDF][nomap]")
     }
 }
 
+SCENARIO("nomap erase middle range preserves correct elements", "[CDF][nomap]")
+{
+    GIVEN("a nomap with five entries")
+    {
+        nomap<std::string, int> map;
+        map["a"] = 1;
+        map["b"] = 2;
+        map["c"] = 3;
+        map["d"] = 4;
+        map["e"] = 5;
+
+        WHEN("erasing a middle range [begin+1, begin+3)")
+        {
+            auto key_at_0 = map.cbegin()->first;
+            auto key_at_1 = (map.cbegin() + 1)->first;
+            auto key_at_2 = (map.cbegin() + 2)->first;
+            auto key_at_3 = (map.cbegin() + 3)->first;
+            auto key_at_4 = (map.cbegin() + 4)->first;
+
+            map.erase(map.cbegin() + 1, map.cbegin() + 3);
+
+            THEN("size is reduced by 2")
+            {
+                REQUIRE(map.size() == 3);
+            }
+            THEN("erased keys are gone and kept keys remain")
+            {
+                REQUIRE(map.find(key_at_1) == map.end());
+                REQUIRE(map.find(key_at_2) == map.end());
+                REQUIRE(map.find(key_at_0) != map.end());
+                REQUIRE(map.find(key_at_3) != map.end());
+                REQUIRE(map.find(key_at_4) != map.end());
+            }
+        }
+    }
+}
+
 SCENARIO("nomap", "[CDF]")
 {
     GIVEN("a map")

--- a/tests/rle_compression/main.cpp
+++ b/tests/rle_compression/main.cpp
@@ -58,3 +58,29 @@ TEST_CASE("IDEMPOTENCY check", "")
     cdf::io::rle::inflate(w2, w.data(), 9);
     REQUIRE(ref == w);
 }
+
+TEST_CASE("inflate stops at output_size boundary", "")
+{
+    // Compressed data that decompresses to 10 bytes: {0,0,0,0,0, 1, 2, 3, 4, 5}
+    // RLE encoding: {0, 4, 1, 2, 3, 4, 5} (5 zeros encoded as 0x00 0x04, then 5 literals)
+    no_init_vector<char> input { 0, 4, 1, 2, 3, 4, 5 };
+    constexpr std::size_t output_size = 6;
+    no_init_vector<char> output(output_size, static_cast<char>(0xFF));
+    auto written = cdf::io::rle::inflate(input, output.data(), output_size);
+    // inflate must not write more than output_size bytes
+    REQUIRE(written <= output_size);
+}
+
+TEST_CASE("inflate handles truncated input (zero byte at end)", "")
+{
+    // Malformed: a zero byte with no following count byte
+    no_init_vector<char> input { 1, 2, 0 };
+    no_init_vector<char> output(16, static_cast<char>(0xFF));
+    // Must not read past end of input — should either stop or return an error,
+    // not dereference past std::cend(input)
+    auto written = cdf::io::rle::inflate(input, output.data(), 16);
+    // At minimum the two literal bytes should have been written
+    REQUIRE(written >= 2);
+    REQUIRE(output[0] == 1);
+    REQUIRE(output[1] == 2);
+}


### PR DESCRIPTION
## Summary

- **RLE inflate**: enforce `output_size` bounds and handle truncated input (OOB write on malformed CDF files)
- **Pre-1972 TT2000**: fix 10-second error in both scalar and SIMD paths (leap second returned 10s instead of 0)
- **`leap_second(tt2000_t)`**: fix off-by-one at exact Jan 1 1972 boundary (`>` → `>=`)
- **`nomap::erase(first, last)`**: accept `last == cend()` and fix return type (was dead code that didn't compile)
- **`var_record_size`**: use `std::size_t` instead of `uint32_t` to avoid truncation on >4GB variable records
- **`MaxRec + 1`**: cast to `uint32_t` before addition to prevent signed integer overflow
- **`_min_cdf_int`**: propagate `OverflowError` for Python ints exceeding `INT64_MAX`

## Test plan

- [x] All 13 C++ tests pass (chrono, nomap, rle_compression, simple_open, etc.)
- [x] Added reproducer tests for RLE bounds (2 tests), pre-1972 TT2000 scalar+SIMD (5 sections), nomap erase (2 scenarios)
- [x] Benchmarks show no performance regression (chrono SIMD, RLE inflate)
- [x] Added RLE benchmark for future regression tracking
- [ ] Python tests need verification with matching Python version (version mismatch on dev machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)