### PR TITLE
Fix CDF_UCHAR shape handling and improve set_values error messages

### DIFF
--- a/pycdfpp/data_types.hpp
+++ b/pycdfpp/data_types.hpp
@@ -502,5 +502,11 @@ inline void _analyze_collection_impl(
     auto result = analyze_result {};
     result.shape = Variable::shape_t { input.shape(), input.shape() + input.ndim() };
     result.inferred_cdf_type = to_cdf_type(input);
+    
+    if (result.inferred_cdf_type == CDF_Types::CDF_UCHAR)
+    {
+        result.shape.push_back(input.dtype().itemsize());
+    }
+    
     return result;
 }

--- a/pycdfpp/variable.hpp
+++ b/pycdfpp/variable.hpp
@@ -49,6 +49,8 @@ using namespace cdf;
 #include <pybind11/stl_bind.h>
 #include <pybind11/warnings.h>
 
+#include <fmt/core.h>
+
 namespace docstrings
 {
 constexpr auto _Variable = R"(
@@ -477,15 +479,15 @@ inline void set_values(Variable& var, const py_list_or_py_tuple auto& values,
         {
             if (not are_compatible_types(*data_type, spec.inferred_cdf_type) and not spec.is_empty)
             {
-                throw std::invalid_argument {
-                    "Incompatible specified CDF data type and input values"
-                };
+                throw std::invalid_argument { fmt::format(
+                    "Incompatible CDF data type: expected {}, but input values have type {}",
+                    cdf_type_str(*data_type), cdf_type_str(spec.inferred_cdf_type)) };
             }
             if (not _details::are_compatible_shapes(var, spec.shape))
             {
-                throw std::invalid_argument {
-                    "Incompatible specified CDF variable shape and input values"
-                };
+                throw std::invalid_argument { fmt::format(
+                    "Incompatible variable shape: expected [{}], got [{}]",
+                    fmt::join(var.shape(), ", "), fmt::join(spec.shape, ", ")) };
             }
         }
     }
@@ -527,9 +529,9 @@ inline void set_values(
         data_type = spec.inferred_cdf_type;
         if (data_type == CDF_Types::CDF_NONE)
         {
-            throw std::invalid_argument {
-                "Could not infer a compatible CDF data type from input numpy array"
-            };
+            throw std::invalid_argument { fmt::format(
+                "Could not infer a compatible CDF data type from numpy array with dtype '{}' and kind '{}'",
+                std::string(py::str(values.dtype())), values.dtype().kind()) };
         }
     }
     else
@@ -538,15 +540,15 @@ inline void set_values(
         {
             if (not are_compatible_types(var.type(), *data_type))
             {
-                throw std::invalid_argument {
-                    "Incompatible specified CDF data type and input values"
-                };
+                throw std::invalid_argument { fmt::format(
+                    "Incompatible specified CDF data type and input values: expected {}, but input has type {}",
+                    cdf_type_str(var.type()), cdf_type_str(spec.inferred_cdf_type)) };
             }
             if (not _details::are_compatible_shapes(var, spec.shape))
             {
-                throw std::invalid_argument {
-                    "Incompatible specified CDF variable shape and input values"
-                };
+                throw std::invalid_argument { fmt::format(
+                    "Incompatible variable shape: expected [{}], got [{}]",
+                    fmt::join(var.shape(), ", "), fmt::join(spec.shape, ", ")) };
             }
         }
     }

--- a/tests/python_variable_set_values/test.py
+++ b/tests/python_variable_set_values/test.py
@@ -57,6 +57,13 @@ class PycdfVariableSetValues(unittest.TestCase):
             shape=[0], dtype=np.float64), data_type=pycdfpp.DataType.CDF_REAL8)
         self.assertIn("variable", cdf)
         cdf["variable"].set_values(np.ones(100, dtype=np.float64))
+        
+    def test_setting_compatible_type_values_should_not_raise_strings(self):
+        cdf = pycdfpp.CDF()
+        cdf.add_variable("variable", values=np.empty(
+            shape=[0], dtype="S4"), data_type=pycdfpp.DataType.CDF_UCHAR)
+        self.assertIn("variable", cdf)
+        cdf["variable"].set_values(np.array(["1234", "4321"]))
 
     def test_setting_different_shape_values_should_raise_1D(self):
         cdf = pycdfpp.CDF()


### PR DESCRIPTION
## Summary
- Fix `_analyze_collection_impl` to append `itemsize` to inferred shape for `CDF_UCHAR` numpy arrays, so string-typed variables pass compatibility checks in `set_values`
- Replace generic error messages in `set_values` with `fmt::format` diagnostics showing expected vs actual types and shapes
- Add test for setting string values on a CDF_UCHAR variable

## Test plan
- [x] Verify `test_setting_compatible_type_values_should_not_raise_strings` passes
- [x] Verify existing `set_values` tests still pass
- [x] Confirm improved error messages appear on type/shape mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)