### PR TITLE
Improve Python exception messages with actionable context

### DIFF
--- a/pycdfpp/attribute.hpp
+++ b/pycdfpp/attribute.hpp
@@ -44,6 +44,8 @@ typedef SSIZE_T ssize_t;
 
 #include "repr.hpp"
 
+#include <fmt/core.h>
+
 using namespace cdf;
 
 #include <pybind11/chrono.h>
@@ -194,8 +196,9 @@ auto visit(string_or_buffer_t& data, Ts... lambdas)
         }
         break;
         default:
-            throw std::runtime_error { std::string { "Unsupported CDF type " }
-                + std::to_string(static_cast<int>(data.type())) };
+            throw std::runtime_error { fmt::format(
+                "Unsupported CDF type {} ({})", cdf_type_str(data.type()),
+                static_cast<int>(data.type())) };
             break;
     }
     return {};
@@ -216,7 +219,9 @@ data_t to_attr_data_entry(const std::string& values, CDF_Types data_type)
     }
     else
     {
-        throw std::invalid_argument { "Incorrect CDF type for string value" };
+        throw std::invalid_argument { fmt::format(
+            "Cannot store string value as {}; expected CDF_CHAR or CDF_UCHAR",
+            cdf_type_str(data_type)) };
     }
 }
 
@@ -225,7 +230,8 @@ data_t _time_to_data_t(const py::buffer& buffer)
 {
     py::buffer_info info = buffer.request();
     if (info.ndim != 1)
-        throw std::invalid_argument { "Incorrect dimension for attribute value" };
+        throw std::invalid_argument { fmt::format(
+            "Attribute time values must be 1-D, got ndim={}", info.ndim) };
     no_init_vector<T> values(info.size);
     std::transform(reinterpret_cast<uint64_t*>(info.ptr),
         reinterpret_cast<uint64_t*>(info.ptr) + info.size, std::begin(values),
@@ -248,10 +254,13 @@ data_t _numeric_to_data_t(const py::buffer& buffer)
 {
     py::buffer_info info = buffer.request();
     if (info.ndim != 1)
-        throw std::invalid_argument { "Incorrect dimension for attribute value" };
+        throw std::invalid_argument { fmt::format(
+            "Attribute numeric values must be 1-D, got ndim={}", info.ndim) };
     using T = from_cdf_type_t<data_type>;
     if (info.itemsize != static_cast<ssize_t>(sizeof(T)))
-        throw std::invalid_argument { "Incompatible python and cdf types" };
+        throw std::invalid_argument { fmt::format(
+            "Buffer itemsize mismatch for {}: expected {} bytes, got {}",
+            cdf_type_str(data_type), sizeof(T), info.itemsize) };
     no_init_vector<T> values(info.size);
     std::memcpy(values.data(), info.ptr, info.size * sizeof(T));
     return data_t { std::move(values), data_type };
@@ -318,7 +327,9 @@ data_t to_attr_data_entry(const py::buffer& buffer, CDF_Types data_type)
             return to_attr_data_entry<cdf::CDF_Types::CDF_TIME_TT2000>(buffer);
             break;
         default:
-            throw std::invalid_argument { "Unsuported CDF Type" };
+            throw std::invalid_argument { fmt::format(
+                "Unsupported CDF type {} ({}) for buffer attribute",
+                cdf_type_str(data_type), static_cast<int>(data_type)) };
             break;
     }
 }
@@ -356,7 +367,8 @@ Attribute::attr_data_t to_attr_data_entries(
     }
     else
     {
-        throw std::invalid_argument { "Attribute already exists" };
+        throw std::invalid_argument { fmt::format(
+            "Global attribute '{}' already exists", name) };
     }
 }
 
@@ -372,7 +384,8 @@ Attribute::attr_data_t to_attr_data_entries(
     }
     else
     {
-        throw std::invalid_argument { "Attribute already exists" };
+        throw std::invalid_argument { fmt::format(
+            "Variable attribute '{}' already exists", name) };
     }
 }
 
@@ -404,8 +417,9 @@ void def_attribute_wrapper(T& mod)
             [](Attribute& att, std::size_t index) -> py_cdf_attr_data_t
             {
                 if (index >= att.size())
-                    throw std::out_of_range(
-                        "Trying to get an attribute value outside of its range");
+                    throw std::out_of_range(fmt::format(
+                        "Attribute index {} out of range for attribute '{}' with {} entries",
+                        index, att.name, att.size()));
                 return to_py_cdf_data(att[index]);
             },
             py::return_value_policy::copy)
@@ -414,8 +428,9 @@ void def_attribute_wrapper(T& mod)
             [](Attribute& att, std::size_t index)
             {
                 if (index >= att.size())
-                    throw std::out_of_range(
-                        "Trying to get an attribute value outside of its range");
+                    throw std::out_of_range(fmt::format(
+                        "Attribute index {} out of range for attribute '{}' with {} entries",
+                        index, att.name, att.size()));
                 return att[index].type();
             });
 
@@ -433,8 +448,9 @@ void def_attribute_wrapper(T& mod)
             [](VariableAttribute& att, std::size_t index) -> py_cdf_attr_data_t
             {
                 if (index != 0)
-                    throw std::out_of_range(
-                        "Trying to get an attribute value outside of its range");
+                    throw std::out_of_range(fmt::format(
+                        "VariableAttribute '{}' index {} out of range (has exactly 1 entry, use .value instead)",
+                        att.name, index));
                 return to_py_cdf_data(*att);
             },
             py::return_value_policy::copy)

--- a/pycdfpp/cdf.hpp
+++ b/pycdfpp/cdf.hpp
@@ -35,6 +35,8 @@
 #include "repr.hpp"
 #include "variable.hpp"
 
+#include <fmt/core.h>
+
 
 using namespace cdf;
 
@@ -97,7 +99,14 @@ void def_cdf_wrapper(T& mod)
             [](CDF& cdf, cdf_compression_type ct) { cdf.compression = ct; })
         .def("__repr__", __repr__<CDF>)
         .def(
-            "__getitem__", [](CDF& cd, const std::string& key) -> Variable& { return cd[key]; },
+            "__getitem__",
+            [](CDF& cd, const std::string& key) -> Variable&
+            {
+                auto it = cd.variables.find(key);
+                if (it == cd.variables.end())
+                    throw py::key_error(key);
+                return it->second;
+            },
             py::return_value_policy::reference_internal)
         .def("__contains__",
             [](const CDF& cd, std::string& key) { return cd.variables.count(key) > 0; })
@@ -132,7 +141,8 @@ void def_cdf_wrapper(T& mod)
                 }
                 else
                 {
-                    throw std::invalid_argument { "Variable already exists" };
+                    throw std::invalid_argument { fmt::format(
+                        "Variable '{}' already exists", name) };
                 }
             },
             py::arg("name"), py::arg("is_nrv") = false,
@@ -153,7 +163,8 @@ void def_cdf_wrapper(T& mod)
                 }
                 else
                 {
-                    throw std::invalid_argument { "Variable already exists" };
+                    throw std::invalid_argument { fmt::format(
+                        "Variable '{}' already exists", name) };
                 }
             },
             py::arg("name"), py::arg("values").noconvert(), py::arg("data_type"),
@@ -171,7 +182,8 @@ void def_cdf_wrapper(T& mod)
                 }
                 else
                 {
-                    throw std::invalid_argument { "Variable already exists" };
+                    throw std::invalid_argument { fmt::format(
+                        "Variable '{}' already exists", var.name()) };
                 }
             },
             py::arg("variable"), py::return_value_policy::reference_internal)
@@ -186,7 +198,8 @@ void def_cdf_wrapper(T& mod)
                 }
                 else
                 {
-                    throw std::invalid_argument { "Variable does not exist" };
+                    throw std::invalid_argument { fmt::format(
+                        "Variable '{}' does not exist", name) };
                 }
             },
             py::arg("name"))
@@ -207,7 +220,8 @@ void def_cdf_wrapper(T& mod)
                 }
                 else
                 {
-                    throw std::invalid_argument { "Attribute already exists" };
+                    throw std::invalid_argument { fmt::format(
+                        "Global attribute '{}' already exists", attr.name) };
                 }
             },
             py::arg("attribute"), py::return_value_policy::reference_internal)
@@ -222,7 +236,8 @@ void def_cdf_wrapper(T& mod)
                 }
                 else
                 {
-                    throw std::invalid_argument { "Attribute does not exist" };
+                    throw std::invalid_argument { fmt::format(
+                        "Global attribute '{}' does not exist", name) };
                 }
             },
             py::arg("name"));
@@ -248,7 +263,8 @@ void def_cdf_loading_functions(T& mod)
         {
             py::buffer_info info(buffer.request());
             if (info.ndim != 1)
-                throw std::runtime_error("Incompatible buffer dimension!");
+                throw std::runtime_error(fmt::format(
+                    "lazy_load requires a 1-D buffer, got ndim={}", info.ndim));
             py::gil_scoped_release release;
             return io::load(static_cast<char*>(info.ptr), info.shape[0], iso_8859_1_to_utf8, true);
         },

--- a/pycdfpp/chrono.hpp
+++ b/pycdfpp/chrono.hpp
@@ -44,6 +44,8 @@ using namespace cdf;
 
 #include <datetime.h>
 
+#include <fmt/core.h>
+
 namespace py = pybind11;
 
 namespace _details
@@ -247,8 +249,9 @@ template <typename time_t>
                 }
                 else
                 {
-                    throw std::invalid_argument(
-                        "Only supports datetime.datetime, tt2000_t, epoch and epoch16 types");
+                    throw std::invalid_argument(fmt::format(
+                        "to_datetime64 only supports datetime.datetime, tt2000_t, epoch and epoch16 types, got {}",
+                        Py_TYPE(const_cast<PyObject*>(obj))->tp_name));
                 }
             }
         })
@@ -308,7 +311,9 @@ template <typename time_t>
 {
     if (!is_dt64ns(input))
     {
-        throw std::invalid_argument("Only supports datetime64[ns] arrays");
+        throw std::invalid_argument(fmt::format(
+            "to_datetime requires a datetime64[ns] array, got dtype '{}'",
+            std::string(input.dtype().attr("str").cast<std::string>())));
     }
     return _details::ranges::transform<py::list, int64_t>(
         input, static_cast<PyObject* (*)(int64_t)>(_details::to_datetime));
@@ -340,7 +345,9 @@ template <typename time_t>
         }
         break;
         default:
-            throw std::invalid_argument("Only supports cdf time types");
+            throw std::invalid_argument(fmt::format(
+                "to_datetime64 requires a CDF time variable (CDF_EPOCH, CDF_EPOCH16, or CDF_TIME_TT2000), got {}",
+                cdf_type_str(input.type())));
             break;
     }
     return result.attr("view")("datetime64[ns]");
@@ -370,7 +377,9 @@ template <typename time_t>
         }
         break;
         default:
-            throw std::out_of_range("Only supports cdf time types");
+            throw std::invalid_argument(fmt::format(
+                "to_datetime requires a CDF time variable (CDF_EPOCH, CDF_EPOCH16, or CDF_TIME_TT2000), got {}",
+                cdf_type_str(input.type())));
             break;
     }
     return py::list {};
@@ -499,7 +508,9 @@ inline py::object to_cdf_time_t(const py::array& input)
     {
         return res;
     }
-    return py::none();
+    throw std::invalid_argument(fmt::format(
+        "Cannot convert array with dtype '{}' to CDF time type",
+        std::string(input.dtype().attr("str").cast<std::string>())));
 }
 
 

--- a/pycdfpp/collections.hpp
+++ b/pycdfpp/collections.hpp
@@ -39,6 +39,8 @@ typedef SSIZE_T ssize_t;
 #include <cdfpp/no_init_vector.hpp>
 using namespace cdf;
 
+#include <fmt/core.h>
+
 #include <pybind11/chrono.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
@@ -538,7 +540,9 @@ namespace ranges
     {
         if (py::len(input) != shape_span[0])
         {
-            throw std::out_of_range("Inconsistent shapes in nested lists/tuples");
+            throw std::out_of_range(fmt::format(
+                "Inconsistent shapes in nested lists/tuples: expected length {}, got {}",
+                shape_span[0], py::len(input)));
         }
         auto view = py_list_or_tuple_view { input };
         for (const PyObject* obj : view)
@@ -547,7 +551,7 @@ namespace ranges
             {
                 if (shape_span.size() < 2)
                 {
-                    throw std::out_of_range("Inconsistent shapes in nested lists/tuples");
+                    throw std::out_of_range("Inconsistent shapes in nested lists/tuples: unexpected nested collection at leaf level");
                 }
                 res_ptr = _transform_inner<T>(
                     py::reinterpret_borrow<py::list>(const_cast<PyObject*>(obj)), f, res_ptr,
@@ -588,7 +592,9 @@ namespace ranges
     {
         if (py::len(input) != shape_span[0])
         {
-            throw std::out_of_range("Inconsistent shapes in nested lists/tuples");
+            throw std::out_of_range(fmt::format(
+                "Inconsistent shapes in nested string lists/tuples: expected length {}, got {}",
+                shape_span[0], py::len(input)));
         }
         auto view = py_list_or_tuple_view { input };
         for (const PyObject* obj : view)
@@ -597,7 +603,7 @@ namespace ranges
             {
                 if (shape_span.size() < 2)
                 {
-                    throw std::out_of_range("Inconsistent shapes in nested lists/tuples");
+                    throw std::out_of_range("Inconsistent shapes in nested string lists/tuples: unexpected nested collection at leaf level");
                 }
                 res_ptr = _string_transform_inner<T>(
                     py::reinterpret_borrow<py::list>(const_cast<PyObject*>(obj)), f, res_ptr,
@@ -675,7 +681,7 @@ namespace ranges
                 }
                 else
                 {
-                    throw std::out_of_range("Conversion failed");
+                    throw std::out_of_range("Time conversion failed for element");
                 }
             }
         }
@@ -733,8 +739,9 @@ namespace ranges
             }
             else
             {
-                throw std::out_of_range(
-                    "Only supports datetime.datetime, tt2000_t, epoch and epoch16 types");
+                throw std::out_of_range(fmt::format(
+                    "Only supports datetime.datetime, tt2000_t, epoch and epoch16 types, got {}",
+                    Py_TYPE(const_cast<PyObject*>(obj))->tp_name));
             }
         }
         return result;

--- a/pycdfpp/data_types.hpp
+++ b/pycdfpp/data_types.hpp
@@ -35,6 +35,9 @@
 #include <cdfpp/chrono/cdf-chrono.hpp>
 #include <cdfpp/no_init_vector.hpp>
 #include <cdfpp_config.h>
+
+#include <fmt/core.h>
+
 using namespace cdf;
 
 
@@ -142,7 +145,7 @@ enum class BestTypeId : uint16_t
     auto r = a | b;
     if (is_invalid_mix(r))
     {
-        throw std::out_of_range("Incompatible types in nested lists/tuples");
+        throw std::out_of_range("Incompatible types in nested lists/tuples: cannot mix strings, numbers, and datetimes");
     }
     return r;
 }
@@ -216,7 +219,8 @@ struct analyze_context
     {
         return { BestTypeId::DateTime, 0, 0, 0 };
     }
-    throw std::runtime_error(fmt::format("Unsupported data type encountered"));
+    throw std::runtime_error(fmt::format("Unsupported data type encountered: {}",
+        Py_TYPE(obj)->tp_name));
     return { BestTypeId::None, 0, 0, 0 };
 }
 
@@ -384,7 +388,9 @@ inline void _analyze_collection_impl(
                     = static_cast<std::size_t>(PyList_Size(const_cast<PyObject*>(obj)));
                 if (ctx.inner_collection_size && (curr_inner_size != *ctx.inner_collection_size))
                 {
-                    throw std::out_of_range("Inconsistent shapes in nested lists/tuples");
+                    throw std::out_of_range(fmt::format(
+                        "Inconsistent shapes in nested lists/tuples at depth {}: expected length {}, got {}",
+                        depth + 1, *ctx.inner_collection_size, curr_inner_size));
                 }
                 else
                 {
@@ -401,7 +407,9 @@ inline void _analyze_collection_impl(
                     = static_cast<std::size_t>(PyTuple_Size(const_cast<PyObject*>(obj)));
                 if (ctx.inner_collection_size && (curr_inner_size != *ctx.inner_collection_size))
                 {
-                    throw std::out_of_range("Inconsistent shapes in nested lists/tuples");
+                    throw std::out_of_range(fmt::format(
+                        "Inconsistent shapes in nested lists/tuples at depth {}: expected length {}, got {}",
+                        depth + 1, *ctx.inner_collection_size, curr_inner_size));
                 }
                 else
                 {

--- a/pycdfpp/variable.hpp
+++ b/pycdfpp/variable.hpp
@@ -50,6 +50,7 @@ using namespace cdf;
 #include <pybind11/warnings.h>
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 
 namespace docstrings
 {
@@ -107,7 +108,8 @@ auto to_numerical(const PyObject* o)
         }
         else
         {
-            throw std::invalid_argument { "Incompatible python and cdf types" };
+            throw std::invalid_argument { fmt::format(
+                "Expected numeric value, got {}", Py_TYPE(const_cast<PyObject*>(o))->tp_name) };
         }
     }
     if constexpr (helpers::is_any_of_v<T, uint8_t, uint16_t, uint32_t, uint64_t>)
@@ -122,7 +124,8 @@ auto to_numerical(const PyObject* o)
         }
         else
         {
-            throw std::invalid_argument { "Incompatible python and cdf types" };
+            throw std::invalid_argument { fmt::format(
+                "Expected numeric value, got {}", Py_TYPE(const_cast<PyObject*>(o))->tp_name) };
         }
     }
     else if constexpr (helpers::is_any_of_v<T, int8_t, int16_t, int32_t, int64_t>)
@@ -137,7 +140,8 @@ auto to_numerical(const PyObject* o)
         }
         else
         {
-            throw std::invalid_argument { "Incompatible python and cdf types" };
+            throw std::invalid_argument { fmt::format(
+                "Expected numeric value, got {}", Py_TYPE(const_cast<PyObject*>(o))->tp_name) };
         }
     }
     else if constexpr (std::is_same_v<float, T>)
@@ -152,7 +156,8 @@ auto to_numerical(const PyObject* o)
         }
         else
         {
-            throw std::invalid_argument { "Incompatible python and cdf types" };
+            throw std::invalid_argument { fmt::format(
+                "Expected numeric value, got {}", Py_TYPE(const_cast<PyObject*>(o))->tp_name) };
         }
     }
 }
@@ -163,7 +168,9 @@ std::pair<data_t, typename Variable::shape_t> _numeric_to_nd_data_t(const py::bu
     py::buffer_info info = buffer.request();
     using T = from_cdf_type_t<data_type>;
     if (info.itemsize != static_cast<ssize_t>(sizeof(T)))
-        throw std::invalid_argument { "Incompatible python and cdf types" };
+        throw std::invalid_argument { fmt::format(
+            "Buffer itemsize mismatch for {}: expected {} bytes, got {}",
+            cdf_type_str(data_type), sizeof(T), info.itemsize) };
     typename Variable::shape_t shape(info.ndim);
     std::copy(std::cbegin(info.shape), std::cend(info.shape), std::begin(shape));
     if (info.size != 0)
@@ -227,7 +234,9 @@ void to_cdf_string_t(PyObject* o, const std::span<T>& out)
     }
     else
     {
-        throw std::invalid_argument { "Incompatible python and cdf string types" };
+        throw std::invalid_argument { fmt::format(
+            "Expected str for CDF string variable, got {}",
+            Py_TYPE(o)->tp_name) };
     }
 }
 
@@ -252,7 +261,9 @@ std::pair<data_t, typename Variable::shape_t> _time_to_nd_data_t(const py::array
     no_init_vector<T> values(arr.size());
     if (!to_cdf_time_t(arr, values.data()))
     {
-        throw std::invalid_argument { "Incompatible python and cdf time types" };
+        throw std::invalid_argument { fmt::format(
+            "Cannot convert numpy array with dtype '{}' to CDF time type {}",
+            std::string(py::str(arr.dtype())), cdf_type_str(data_type)) };
     }
     return { data_t { std::move(values), data_type }, std::move(shape) };
 }
@@ -459,7 +470,9 @@ struct _min_storage_result
         }
         else
         {
-            throw std::invalid_argument { "Unsupported data type in input values" };
+            throw std::invalid_argument { fmt::format(
+                "Unsupported data type in input values: {}",
+                Py_TYPE(const_cast<PyObject*>(obj))->tp_name) };
         }
     }
     return CDF_Types::CDF_NONE;
@@ -642,11 +655,17 @@ void def_variable_wrapper(T& mod)
                 if (var.type() != CDF_Types::CDF_NONE and not force)
                 {
                     if (var.type() != source.type())
-                        throw std::invalid_argument { "Incompatible variable types" };
+                        throw std::invalid_argument { fmt::format(
+                            "Incompatible variable types: destination is {}, source is {}",
+                            cdf_type_str(var.type()), cdf_type_str(source.type())) };
                     if (var.is_nrv() != source.is_nrv())
-                        throw std::invalid_argument { "Incompatible variable record vary" };
+                        throw std::invalid_argument { fmt::format(
+                            "Incompatible record variance: destination is_nrv={}, source is_nrv={}",
+                            var.is_nrv(), source.is_nrv()) };
                     if (var.shape() != source.shape())
-                        throw std::invalid_argument { "Incompatible variable shapes" };
+                        throw std::invalid_argument { fmt::format(
+                            "Incompatible variable shapes: destination [{}], source [{}]",
+                            fmt::join(var.shape(), ", "), fmt::join(source.shape(), ", ")) };
                 }
                 var.set_data(source);
             },
@@ -667,7 +686,8 @@ void def_variable_wrapper(T& mod)
                 }
                 else
                 {
-                    throw std::invalid_argument { "Attribute already exists" };
+                    throw std::invalid_argument { fmt::format(
+                        "Variable attribute '{}' already exists", attr.name) };
                 }
             },
             py::arg("attribute"), py::return_value_policy::reference_internal);


### PR DESCRIPTION
## Summary

- Every exception in pycdfpp now includes relevant names, types, shapes, or indices so users can diagnose issues without a debugger
- Fixes `CDF.__getitem__` to raise `KeyError` instead of `IndexError` on missing variables
- Fixes `to_datetime(Variable)` to raise `ValueError` consistently (was `IndexError` via `std::out_of_range`)
- Fixes `to_cdf_time_t` to raise on unrecognized array dtype instead of silently returning `None`
- Fixes "Unsuported" typo in error message

## Test plan

- [x] All 5 Python test suites pass (80 tests)
- [x] All C++ test suites pass
- [x] Clean build from scratch with no warnings in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)