### PR TITLE
Apply high-value C++20 modernizations

### DIFF
--- a/include/cdfpp/cdf-data.hpp
+++ b/include/cdfpp/cdf-data.hpp
@@ -394,226 +394,54 @@ template <CDF_Types _type>
 
 inline const char* data_t::bytes_ptr() const
 {
-    switch (this->type())
-    {
-        case cdf::CDF_Types::CDF_BYTE:
-        case cdf::CDF_Types::CDF_INT1:
-            return reinterpret_cast<const char*>(this->get<int8_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_UINT1:
-            return reinterpret_cast<const char*>(this->get<uint8_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_INT2:
-            return reinterpret_cast<const char*>(this->get<int16_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_INT4:
-            return reinterpret_cast<const char*>(this->get<int32_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_INT8:
-            return reinterpret_cast<const char*>(this->get<int64_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_UINT2:
-            return reinterpret_cast<const char*>(this->get<uint16_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_UINT4:
-            return reinterpret_cast<const char*>(this->get<uint32_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_DOUBLE:
-        case cdf::CDF_Types::CDF_REAL8:
-            return reinterpret_cast<const char*>(this->get<double>().data());
-            break;
-        case cdf::CDF_Types::CDF_FLOAT:
-        case cdf::CDF_Types::CDF_REAL4:
-            return reinterpret_cast<const char*>(this->get<float>().data());
-            break;
-        case cdf::CDF_Types::CDF_EPOCH:
-            return reinterpret_cast<const char*>(this->get<epoch>().data());
-            break;
-        case cdf::CDF_Types::CDF_EPOCH16:
-            return reinterpret_cast<const char*>(this->get<epoch16>().data());
-            break;
-        case cdf::CDF_Types::CDF_TIME_TT2000:
-            return reinterpret_cast<const char*>(this->get<tt2000_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_UCHAR:
-            return reinterpret_cast<const char*>(this->get<cdf::CDF_Types::CDF_UCHAR>().data());
-            break;
-        case cdf::CDF_Types::CDF_CHAR:
-            return reinterpret_cast<const char*>(this->get<cdf::CDF_Types::CDF_CHAR>().data());
-            break;
-        default:
-            return nullptr;
-            break;
-    }
-    return nullptr;
+    return std::visit(
+        [](const auto& v) -> const char*
+        {
+            if constexpr (std::is_same_v<std::decay_t<decltype(v)>, cdf_none>)
+                return nullptr;
+            else
+                return reinterpret_cast<const char*>(v.data());
+        },
+        p_values);
 }
 
 inline char* data_t::bytes_ptr()
 {
-    switch (this->type())
-    {
-        case cdf::CDF_Types::CDF_BYTE:
-        case cdf::CDF_Types::CDF_INT1:
-            return reinterpret_cast<char*>(this->get<int8_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_UINT1:
-            return reinterpret_cast<char*>(this->get<uint8_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_INT2:
-            return reinterpret_cast<char*>(this->get<int16_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_INT4:
-            return reinterpret_cast<char*>(this->get<int32_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_INT8:
-            return reinterpret_cast<char*>(this->get<int64_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_UINT2:
-            return reinterpret_cast<char*>(this->get<uint16_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_UINT4:
-            return reinterpret_cast<char*>(this->get<uint32_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_DOUBLE:
-        case cdf::CDF_Types::CDF_REAL8:
-            return reinterpret_cast<char*>(this->get<double>().data());
-            break;
-        case cdf::CDF_Types::CDF_FLOAT:
-        case cdf::CDF_Types::CDF_REAL4:
-            return reinterpret_cast<char*>(this->get<float>().data());
-            break;
-        case cdf::CDF_Types::CDF_EPOCH:
-            return reinterpret_cast<char*>(this->get<epoch>().data());
-            break;
-        case cdf::CDF_Types::CDF_EPOCH16:
-            return reinterpret_cast<char*>(this->get<epoch16>().data());
-            break;
-        case cdf::CDF_Types::CDF_TIME_TT2000:
-            return reinterpret_cast<char*>(this->get<tt2000_t>().data());
-            break;
-        case cdf::CDF_Types::CDF_UCHAR:
-            return reinterpret_cast<char*>(this->get<cdf::CDF_Types::CDF_UCHAR>().data());
-            break;
-        case cdf::CDF_Types::CDF_CHAR:
-            return reinterpret_cast<char*>(this->get<cdf::CDF_Types::CDF_CHAR>().data());
-            break;
-        default:
-            return nullptr;
-            break;
-    }
-    return nullptr;
+    return std::visit(
+        [](auto& v) -> char*
+        {
+            if constexpr (std::is_same_v<std::decay_t<decltype(v)>, cdf_none>)
+                return nullptr;
+            else
+                return reinterpret_cast<char*>(v.data());
+        },
+        p_values);
 }
 
 inline std::size_t data_t::size() const noexcept
 {
-    switch (this->type())
-    {
-        case cdf::CDF_Types::CDF_BYTE:
-        case cdf::CDF_Types::CDF_INT1:
-            return std::size(this->get<int8_t>());
-            break;
-        case cdf::CDF_Types::CDF_UINT1:
-            return std::size(this->get<uint8_t>());
-            break;
-        case cdf::CDF_Types::CDF_INT2:
-            return std::size(this->get<int16_t>());
-            break;
-        case cdf::CDF_Types::CDF_INT4:
-            return std::size(this->get<int32_t>());
-            break;
-        case cdf::CDF_Types::CDF_INT8:
-            return std::size(this->get<int64_t>());
-            break;
-        case cdf::CDF_Types::CDF_UINT2:
-            return std::size(this->get<uint16_t>());
-            break;
-        case cdf::CDF_Types::CDF_UINT4:
-            return std::size(this->get<uint32_t>());
-            break;
-        case cdf::CDF_Types::CDF_DOUBLE:
-        case cdf::CDF_Types::CDF_REAL8:
-            return std::size(this->get<double>());
-            break;
-        case cdf::CDF_Types::CDF_FLOAT:
-        case cdf::CDF_Types::CDF_REAL4:
-            return std::size(this->get<float>());
-            break;
-        case cdf::CDF_Types::CDF_EPOCH:
-            return std::size(this->get<epoch>());
-            break;
-        case cdf::CDF_Types::CDF_EPOCH16:
-            return std::size(this->get<epoch16>());
-            break;
-        case cdf::CDF_Types::CDF_TIME_TT2000:
-            return std::size(this->get<tt2000_t>());
-            break;
-        case cdf::CDF_Types::CDF_UCHAR:
-            return std::size(this->get<cdf::CDF_Types::CDF_UCHAR>());
-            break;
-        case cdf::CDF_Types::CDF_CHAR:
-            return std::size(this->get<cdf::CDF_Types::CDF_CHAR>());
-            break;
-        default:
-            return 0;
-            break;
-    }
-    return 0;
+    return std::visit(
+        [](const auto& v) -> std::size_t
+        {
+            if constexpr (std::is_same_v<std::decay_t<decltype(v)>, cdf_none>)
+                return 0;
+            else
+                return std::size(v);
+        },
+        p_values);
 }
 
 inline std::size_t data_t::bytes() const noexcept
 {
-    switch (this->type())
-    {
-        case cdf::CDF_Types::CDF_BYTE:
-        case cdf::CDF_Types::CDF_INT1:
-            return std::size(this->get<int8_t>());
-            break;
-        case cdf::CDF_Types::CDF_UINT1:
-            return std::size(this->get<uint8_t>());
-            break;
-        case cdf::CDF_Types::CDF_INT2:
-            return std::size(this->get<int16_t>()) * 2;
-            break;
-        case cdf::CDF_Types::CDF_INT4:
-            return std::size(this->get<int32_t>()) * 4;
-            break;
-        case cdf::CDF_Types::CDF_INT8:
-            return std::size(this->get<int64_t>()) * 8;
-            break;
-        case cdf::CDF_Types::CDF_UINT2:
-            return std::size(this->get<uint16_t>()) * 2;
-            break;
-        case cdf::CDF_Types::CDF_UINT4:
-            return std::size(this->get<uint32_t>()) * 4;
-            break;
-        case cdf::CDF_Types::CDF_DOUBLE:
-        case cdf::CDF_Types::CDF_REAL8:
-            return std::size(this->get<double>()) * 8;
-            break;
-        case cdf::CDF_Types::CDF_FLOAT:
-        case cdf::CDF_Types::CDF_REAL4:
-            return std::size(this->get<float>()) * 4;
-            break;
-        case cdf::CDF_Types::CDF_EPOCH:
-            return std::size(this->get<epoch>()) * sizeof(epoch);
-            break;
-        case cdf::CDF_Types::CDF_EPOCH16:
-            return std::size(this->get<epoch16>()) * sizeof(epoch16);
-            break;
-        case cdf::CDF_Types::CDF_TIME_TT2000:
-            return std::size(this->get<tt2000_t>()) * sizeof(tt2000_t);
-            break;
-        case cdf::CDF_Types::CDF_UCHAR:
-            return std::size(this->get<cdf::CDF_Types::CDF_UCHAR>());
-            break;
-        case cdf::CDF_Types::CDF_CHAR:
-            return std::size(this->get<cdf::CDF_Types::CDF_CHAR>());
-            break;
-        default:
-            return 0;
-            break;
-    }
-    return 0;
+    return std::visit(
+        [](const auto& v) -> std::size_t
+        {
+            if constexpr (std::is_same_v<std::decay_t<decltype(v)>, cdf_none>)
+                return 0;
+            else
+                return std::size(v) * sizeof(typename std::decay_t<decltype(v)>::value_type);
+        },
+        p_values);
 }
 
 [[nodiscard]] constexpr bool is_string(const CDF_Types type)

--- a/include/cdfpp/cdf-io/endianness.hpp
+++ b/include/cdfpp/cdf-io/endianness.hpp
@@ -24,18 +24,11 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #pragma once
-#include "cdfpp_config.h"
-#ifdef CDFpp_BIG_ENDIAN
-inline const bool host_is_big_endian = true;
-inline const bool host_is_little_endian = false;
-#else
-#ifdef CDFpp_LITTLE_ENDIAN
-inline const bool host_is_big_endian = false;
-inline const bool host_is_little_endian = true;
-#else
-#error "Can't find if platform is either big or little endian"
-#endif
-#endif
+#include <bit>
+
+inline constexpr bool host_is_big_endian = (std::endian::native == std::endian::big);
+inline constexpr bool host_is_little_endian = (std::endian::native == std::endian::little);
+static_assert(host_is_big_endian || host_is_little_endian, "Mixed-endian platforms are not supported");
 
 #ifdef __GNUC__
 #define bswap16 __builtin_bswap16
@@ -52,12 +45,9 @@ inline const bool host_is_little_endian = true;
 
 #include "../cdf-debug.hpp"
 #include "../cdf-enums.hpp"
-#include <algorithm>
 #include <cstring>
 #include <stdint.h>
 #include <type_traits>
-
-#include <iostream>
 
 namespace cdf::endianness
 {
@@ -119,20 +109,6 @@ namespace
     template <std::size_t s>
     using uint_t = typename uint<s>::type;
 
-    template <typename T>
-    union swapable_t
-    {
-        static inline constexpr bool is_int = std::is_same_v<T, uint_t<sizeof(T)>>;
-        uint_t<sizeof(T)> int_view;
-        T value;
-        template <bool disable = is_int>
-        swapable_t(T v, typename std::enable_if<!disable>::type* = 0) : value { v }
-        {
-        }
-        swapable_t(uint_t<sizeof(T)> v) : int_view { v } { }
-    };
-
-
     [[nodiscard]] inline uint8_t bswap(uint8_t v) noexcept
     {
         return v;
@@ -150,10 +126,10 @@ namespace
         return bswap64(v);
     }
 
-    template <typename T, std::size_t s = sizeof(T)>
+    template <typename T>
     [[nodiscard]] inline T byte_swap(T value) noexcept
     {
-        return swapable_t<T> { bswap(swapable_t<T> { value }.int_view) }.value;
+        return std::bit_cast<T>(bswap(std::bit_cast<uint_t<sizeof(T)>>(value)));
     }
 }
 

--- a/include/cdfpp/cdf-io/loading/records-loading.hpp
+++ b/include/cdfpp/cdf-io/loading/records-loading.hpp
@@ -239,9 +239,9 @@ struct blk_iterator
             wrapper_load(offset, std::make_index_sequence<sizeof...(Args)> {});
     }
 
-    auto operator==(const blk_iterator& other) { return other.offset == offset; }
+    bool operator==(const blk_iterator& other) const { return other.offset == offset; }
 
-    bool operator!=(const blk_iterator& other) { return not(*this == other); }
+    bool operator!=(const blk_iterator& other) const { return not(*this == other); }
 
     blk_iterator& operator+(int n)
     {


### PR DESCRIPTION
## Summary

- Replace `swapable_t` union type-punning with `std::bit_cast` in `endianness.hpp` — eliminates technically-UB code
- Replace `CDFpp_BIG/LITTLE_ENDIAN` build-system macros with `std::endian::native` — removes configure-time dependency, makes `host_is_*_endian` `constexpr`
- Fix `blk_iterator::operator==` missing `const` qualifier — was violating `forward_iterator` requirements
- Replace 4 duplicate ~55-line switch blocks in `cdf-data.hpp` (`bytes_ptr` const/non-const, `size`, `bytes`) with `std::visit` over the variant — net **-196 lines**

## Test plan

- [x] All 19 C++ test suites pass (0 failures)
- [x] All 5 Python test suites pass (80 tests)
- [x] Clean build with no new warnings in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)