### PR TITLE
C++20 modernizations batch 2

### DIFF
--- a/include/cdfpp/attribute.hpp
+++ b/include/cdfpp/attribute.hpp
@@ -68,8 +68,6 @@ struct Attribute
         return other.name == name && other.data == data;
     }
 
-    inline bool operator!=(const Attribute& other) const { return !(*this == other); }
-
     template <CDF_Types type>
     [[nodiscard]] inline decltype(auto) get(std::size_t index)
     {
@@ -192,8 +190,6 @@ struct VariableAttribute
     {
         return other.name == name && other.data == data;
     }
-
-    inline bool operator!=(const VariableAttribute& other) const { return !(*this == other); }
 
     inline CDF_Types type() const noexcept { return data.type(); }
 

--- a/include/cdfpp/cdf-data.hpp
+++ b/include/cdfpp/cdf-data.hpp
@@ -86,15 +86,13 @@ struct data_t
         return other.p_type == p_type && other.p_values == p_values;
     }
 
-    inline bool operator!=(const data_t& other) const { return !(*this == other); }
-
     data_t() : p_values { cdf_none {} }, p_type { CDF_Types::CDF_NONE } { }
     data_t(const data_t& other) = default;
     data_t(data_t&& other) = default;
 
 
-    template <typename T, typename Dummy = void,
-        typename = std::enable_if_t<!std::is_same_v<std::remove_reference_t<T>, data_t>, Dummy>>
+    template <typename T>
+        requires(!std::is_same_v<std::remove_reference_t<T>, data_t>)
     explicit data_t(T&& values)
             : p_values { std::forward<T>(values) }
             , p_type { to_cdf_type<typename std::remove_reference_t<T>::value_type>() }
@@ -143,13 +141,13 @@ private:
 template <typename... Ts>
 auto visit(data_t& data, Ts... lambdas)
 {
-    return std::visit(helpers::make_visitor(lambdas...), data.p_values);
+    return std::visit(helpers::Visitor { lambdas... }, data.p_values);
 }
 
 template <typename... Ts>
 auto visit(const data_t& data, Ts... lambdas)
 {
-    return std::visit(helpers::make_visitor(lambdas...), data.p_values);
+    return std::visit(helpers::Visitor { lambdas... }, data.p_values);
 }
 
 template <CDF_Types type, typename endianness_t>

--- a/include/cdfpp/cdf-enums.hpp
+++ b/include/cdfpp/cdf-enums.hpp
@@ -49,16 +49,13 @@ enum class cdf_majority
 
 [[nodiscard]] inline std::string cdf_majority_str(cdf_majority type) noexcept
 {
+    using enum cdf_majority;
     switch (type)
     {
-        case cdf_majority::row:
+        case row:
             return "row";
-            break;
-        case cdf_majority::column:
+        case column:
             return "column";
-            break;
-        default:
-            break;
     }
     return "Unknown";
 }
@@ -105,25 +102,19 @@ enum class cdf_compression_type : int32_t
 
 [[nodiscard]] inline std::string cdf_compression_type_str(cdf_compression_type type) noexcept
 {
+    using enum cdf_compression_type;
     switch (type)
     {
-        case cdf_compression_type::no_compression:
+        case no_compression:
             return "None";
-            break;
-        case cdf_compression_type::ahuff_compression:
+        case ahuff_compression:
             return "Adaptative Huffman";
-            break;
-        case cdf_compression_type::huff_compression:
+        case huff_compression:
             return "Huffman";
-            break;
-        case cdf_compression_type::rle_compression:
+        case rle_compression:
             return "Run-Length Encoding";
-            break;
-        case cdf_compression_type::gzip_compression:
+        case gzip_compression:
             return "GNU GZIP";
-            break;
-        default:
-            break;
     }
     return "Unknown";
 }
@@ -201,6 +192,7 @@ consteval bool is_cdf_floating_point_type(CDF_Types type)
 struct tt2000_t
 {
     int64_t nseconds;
+    bool operator==(const tt2000_t&) const = default;
 };
 
 static inline tt2000_t operator""_tt2k(unsigned long long __val)
@@ -208,31 +200,20 @@ static inline tt2000_t operator""_tt2k(unsigned long long __val)
     return tt2000_t { static_cast<int64_t>(__val) };
 }
 
-inline bool operator==(const tt2000_t& lhs, const tt2000_t& rhs)
-{
-    return lhs.nseconds == rhs.nseconds;
-}
-
 // number of milliseconds since 01-Jan-0000 00:00:00.000
 struct epoch
 {
     double mseconds;
+    bool operator==(const epoch&) const = default;
 };
-inline bool operator==(const epoch& lhs, const epoch& rhs)
-{
-    return lhs.mseconds == rhs.mseconds;
-}
 
 // number of picoseconds since 01-Jan-0000 00:00:00.000.000.000.000
 struct epoch16
 {
     double seconds;
     double picoseconds;
+    bool operator==(const epoch16&) const = default;
 };
-inline bool operator==(const epoch16& lhs, const epoch16& rhs)
-{
-    return lhs.seconds == rhs.seconds && lhs.picoseconds == rhs.picoseconds;
-}
 
 template <typename T>
 concept cdf_time_t = std::is_same_v<T, cdf::tt2000_t> || std::is_same_v<T, cdf::epoch>
@@ -301,31 +282,32 @@ constexpr auto from_cdf_type()
 
 [[nodiscard]] inline std::size_t cdf_type_size(CDF_Types type)
 {
+    using enum CDF_Types;
     switch (type)
     {
-        case CDF_Types::CDF_NONE:
+        case CDF_NONE:
             return 0;
-        case CDF_Types::CDF_INT1:
-        case CDF_Types::CDF_UINT1:
-        case CDF_Types::CDF_BYTE:
-        case CDF_Types::CDF_CHAR:
-        case CDF_Types::CDF_UCHAR:
+        case CDF_INT1:
+        case CDF_UINT1:
+        case CDF_BYTE:
+        case CDF_CHAR:
+        case CDF_UCHAR:
             return 1;
-        case CDF_Types::CDF_INT2:
-        case CDF_Types::CDF_UINT2:
+        case CDF_INT2:
+        case CDF_UINT2:
             return 2;
-        case CDF_Types::CDF_INT4:
-        case CDF_Types::CDF_UINT4:
-        case CDF_Types::CDF_FLOAT:
-        case CDF_Types::CDF_REAL4:
+        case CDF_INT4:
+        case CDF_UINT4:
+        case CDF_FLOAT:
+        case CDF_REAL4:
             return 4;
-        case CDF_Types::CDF_INT8:
-        case CDF_Types::CDF_REAL8:
-        case CDF_Types::CDF_DOUBLE:
-        case CDF_Types::CDF_EPOCH:
-        case CDF_Types::CDF_TIME_TT2000:
+        case CDF_INT8:
+        case CDF_REAL8:
+        case CDF_DOUBLE:
+        case CDF_EPOCH:
+        case CDF_TIME_TT2000:
             return 8;
-        case CDF_Types::CDF_EPOCH16:
+        case CDF_EPOCH16:
             return 16;
     }
     return 0;
@@ -333,43 +315,44 @@ constexpr auto from_cdf_type()
 
 [[nodiscard]] inline std::string cdf_type_str(CDF_Types type) noexcept
 {
+    using enum CDF_Types;
     switch (type)
     {
-        case CDF_Types::CDF_NONE:
+        case CDF_NONE:
             return "CDF_NONE";
-        case CDF_Types::CDF_INT1:
+        case CDF_INT1:
             return "CDF_INT1";
-        case CDF_Types::CDF_UINT1:
+        case CDF_UINT1:
             return "CDF_UINT1";
-        case CDF_Types::CDF_BYTE:
+        case CDF_BYTE:
             return "CDF_BYTE";
-        case CDF_Types::CDF_CHAR:
+        case CDF_CHAR:
             return "CDF_CHAR";
-        case CDF_Types::CDF_UCHAR:
+        case CDF_UCHAR:
             return "CDF_UCHAR";
-        case CDF_Types::CDF_INT2:
+        case CDF_INT2:
             return "CDF_INT2";
-        case CDF_Types::CDF_UINT2:
+        case CDF_UINT2:
             return "CDF_UINT2";
-        case CDF_Types::CDF_INT4:
+        case CDF_INT4:
             return "CDF_INT4";
-        case CDF_Types::CDF_UINT4:
+        case CDF_UINT4:
             return "CDF_UINT4";
-        case CDF_Types::CDF_FLOAT:
+        case CDF_FLOAT:
             return "CDF_FLOAT";
-        case CDF_Types::CDF_REAL4:
+        case CDF_REAL4:
             return "CDF_REAL4";
-        case CDF_Types::CDF_INT8:
+        case CDF_INT8:
             return "CDF_INT8";
-        case CDF_Types::CDF_REAL8:
+        case CDF_REAL8:
             return "CDF_REAL8";
-        case CDF_Types::CDF_DOUBLE:
+        case CDF_DOUBLE:
             return "CDF_DOUBLE";
-        case CDF_Types::CDF_TIME_TT2000:
+        case CDF_TIME_TT2000:
             return "CDF_TIME_TT2000";
-        case CDF_Types::CDF_EPOCH:
+        case CDF_EPOCH:
             return "CDF_EPOCH";
-        case CDF_Types::CDF_EPOCH16:
+        case CDF_EPOCH16:
             return "CDF_EPOCH16";
     }
     return "unknown type";
@@ -414,63 +397,63 @@ using from_cdf_type_t = decltype(from_cdf_type<type>());
 
 [[nodiscard]] inline auto cdf_type_dispatch(CDF_Types cdf_type, auto&& f, auto&&... args)
 {
+    using enum CDF_Types;
     switch (cdf_type)
     {
-        case CDF_Types::CDF_UCHAR:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_UCHAR>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_CHAR:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_CHAR>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_BYTE:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_BYTE>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_INT1:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_INT1>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_UINT1:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_UINT1>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_INT2:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_INT2>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_UINT2:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_UINT2>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_INT4:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_INT4>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_UINT4:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_UINT4>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_INT8:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_INT8>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_FLOAT:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_FLOAT>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_REAL4:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_REAL4>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_DOUBLE:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_DOUBLE>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_REAL8:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_REAL8>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_EPOCH:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_EPOCH>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_EPOCH16:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_EPOCH16>(
-            std::forward<decltype(args)>(args)...);
-        case CDF_Types::CDF_TIME_TT2000:
-            return  std::forward<decltype(f)>(f).template operator()<CDF_Types::CDF_TIME_TT2000>(
-            std::forward<decltype(args)>(args)...);
+        case CDF_UCHAR:
+            return std::forward<decltype(f)>(f).template operator()<CDF_UCHAR>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_CHAR:
+            return std::forward<decltype(f)>(f).template operator()<CDF_CHAR>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_BYTE:
+            return std::forward<decltype(f)>(f).template operator()<CDF_BYTE>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_INT1:
+            return std::forward<decltype(f)>(f).template operator()<CDF_INT1>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_UINT1:
+            return std::forward<decltype(f)>(f).template operator()<CDF_UINT1>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_INT2:
+            return std::forward<decltype(f)>(f).template operator()<CDF_INT2>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_UINT2:
+            return std::forward<decltype(f)>(f).template operator()<CDF_UINT2>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_INT4:
+            return std::forward<decltype(f)>(f).template operator()<CDF_INT4>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_UINT4:
+            return std::forward<decltype(f)>(f).template operator()<CDF_UINT4>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_INT8:
+            return std::forward<decltype(f)>(f).template operator()<CDF_INT8>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_FLOAT:
+            return std::forward<decltype(f)>(f).template operator()<CDF_FLOAT>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_REAL4:
+            return std::forward<decltype(f)>(f).template operator()<CDF_REAL4>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_DOUBLE:
+            return std::forward<decltype(f)>(f).template operator()<CDF_DOUBLE>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_REAL8:
+            return std::forward<decltype(f)>(f).template operator()<CDF_REAL8>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_EPOCH:
+            return std::forward<decltype(f)>(f).template operator()<CDF_EPOCH>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_EPOCH16:
+            return std::forward<decltype(f)>(f).template operator()<CDF_EPOCH16>(
+                std::forward<decltype(args)>(args)...);
+        case CDF_TIME_TT2000:
+            return std::forward<decltype(f)>(f).template operator()<CDF_TIME_TT2000>(
+                std::forward<decltype(args)>(args)...);
         default:
             throw std::runtime_error { std::string { "Unsupported CDF type " }
                 + std::to_string(static_cast<int>(cdf_type)) };
-            break;
     }
 }
 }

--- a/include/cdfpp/cdf-file.hpp
+++ b/include/cdfpp/cdf-file.hpp
@@ -74,8 +74,6 @@ struct CDF
             && (other.attributes == attributes) && (other.variables == variables);
     }
 
-    inline bool operator!=(const CDF& other) const { return !(*this == other); }
-
     [[nodiscard]] const Variable& operator[](const std::string& name) const
     {
         return variables.at(name);

--- a/include/cdfpp/cdf-helpers.hpp
+++ b/include/cdfpp/cdf-helpers.hpp
@@ -38,15 +38,8 @@ namespace helpers
     template <typename... Ts>
     struct Visitor : Ts...
     {
-        Visitor(const Ts&... args) : Ts(args)... { }
         using Ts::operator()...;
     };
-
-    template <typename... Ts>
-    auto make_visitor(Ts... lambdas)
-    {
-        return Visitor<Ts...>(lambdas...);
-    }
 
     consteval bool is_in(const auto& value, const auto&... values)
     {

--- a/include/cdfpp/cdf-helpers.hpp
+++ b/include/cdfpp/cdf-helpers.hpp
@@ -40,6 +40,9 @@ namespace helpers
     {
         using Ts::operator()...;
     };
+    // Apple Clang 15 lacks aggregate CTAD — explicit guide needed
+    template <typename... Ts>
+    Visitor(Ts...) -> Visitor<Ts...>;
 
     consteval bool is_in(const auto& value, const auto&... values)
     {

--- a/include/cdfpp/cdf-io/loading/buffers.hpp
+++ b/include/cdfpp/cdf-io/loading/buffers.hpp
@@ -57,8 +57,8 @@ constexpr auto get_data_ptr(buffer_t& buffer) -> decltype(buffer.data())
 }
 
 template <typename buffer_t>
-constexpr auto get_data_ptr(
-    buffer_t& buffer, typename std::enable_if<std::is_pointer_v<buffer_t>>::type* = 0)
+    requires std::is_pointer_v<buffer_t>
+constexpr auto get_data_ptr(buffer_t& buffer)
 {
     return buffer;
 }
@@ -168,20 +168,19 @@ struct array_adapter
     const std::size_t size;
     using implements_view = std::true_type;
 
-    template <bool owns = takes_ownership>
-    array_adapter(const array_t& array, typename std::enable_if<!owns>::type* = 0)
+    array_adapter(const array_t& array)
+        requires(!takes_ownership)
             : without_ownership<array_t> { array }, size { std::size(array) }
     {
     }
-    template <bool owns = takes_ownership>
-    array_adapter(const array_t& array, std::size_t size, typename std::enable_if<!owns>::type* = 0)
+    array_adapter(const array_t& array, std::size_t size)
+        requires(!takes_ownership)
             : without_ownership<array_t> { array }, size { size }
     {
     }
 
-    template <bool owns = takes_ownership>
-    array_adapter(array_t&& array,
-        typename std::enable_if<owns or std::is_rvalue_reference_v<array_t>>::type* = 0)
+    array_adapter(array_t&& array)
+        requires(takes_ownership || std::is_rvalue_reference_v<array_t>)
             : with_ownership<array_t> { std::move(array) }, size { std::size(this->array) }
     {
     }
@@ -215,16 +214,12 @@ struct array_adapter
         impl_read(dest, offset, size);
     }
 
-    template <bool is_ptr = std::is_pointer_v<array_t>>
-    const char* data(typename std::enable_if<is_ptr>::type* = 0) const
+    const char* data() const
     {
-        return this->array;
-    }
-
-    template <bool is_ptr = std::is_pointer_v<array_t>>
-    const char* data(typename std::enable_if<!is_ptr>::type* = 0) const
-    {
-        return this->array.data();
+        if constexpr (std::is_pointer_v<array_t>)
+            return this->array;
+        else
+            return this->array.data();
     }
 
     bool is_valid() const { return size != 0; }

--- a/include/cdfpp/cdf-io/loading/records-loading.hpp
+++ b/include/cdfpp/cdf-io/loading/records-loading.hpp
@@ -179,7 +179,7 @@ struct cdf_mutable_variable_record_t
     template <typename... Ts>
     auto visit(Ts... lambdas) const
     {
-        return std::visit(helpers::make_visitor(lambdas...), actual_record);
+        return std::visit(helpers::Visitor { lambdas... }, actual_record);
     }
 };
 
@@ -188,27 +188,24 @@ std::size_t load_mut_record(
     cdf_mutable_variable_record_t<T>& s, const U& parsing_context, std::size_t offset)
 {
     using mutable_record = cdf_mutable_variable_record_t<T>;
+    using enum cdf_record_type;
     load_record(s.header, parsing_context, offset);
     switch (s.header.record_type)
     {
-        case cdf_record_type::CVVR:
+        case CVVR:
             s.actual_record.template emplace<typename mutable_record::cvvr_t>();
             return load_record(std::get<typename mutable_record::cvvr_t>(s.actual_record),
                 parsing_context, offset);
-            break;
-        case cdf_record_type::VVR:
+        case VVR:
             s.actual_record.template emplace<typename mutable_record::vvr_t>();
             return load_record(
                 std::get<typename mutable_record::vvr_t>(s.actual_record), parsing_context, offset);
-            break;
-        case cdf_record_type::VXR:
+        case VXR:
             s.actual_record.template emplace<typename mutable_record::vxr_t>();
             return load_record(
                 std::get<typename mutable_record::vxr_t>(s.actual_record), parsing_context, offset);
-            break;
         default:
             return 0;
-            break;
     }
 }
 
@@ -240,8 +237,6 @@ struct blk_iterator
     }
 
     bool operator==(const blk_iterator& other) const { return other.offset == offset; }
-
-    bool operator!=(const blk_iterator& other) const { return not(*this == other); }
 
     blk_iterator& operator+(int n)
     {

--- a/include/cdfpp/cdf-io/majority-swap.hpp
+++ b/include/cdfpp/cdf-io/majority-swap.hpp
@@ -174,51 +174,52 @@ void swap(data_t& data, const shape_t& shape)
 
 void swap(data_t& data, const no_init_vector<uint32_t>& shape)
 {
+    using enum CDF_Types;
     switch (data.type())
     {
-        case CDF_Types::CDF_BYTE:
-        case CDF_Types::CDF_INT1:
+        case CDF_BYTE:
+        case CDF_INT1:
             swap<false>(data.get<int8_t>(), shape);
             break;
-        case CDF_Types::CDF_CHAR:
+        case CDF_CHAR:
             swap<true>(data.get<CDF_Types::CDF_CHAR>(), shape);
             break;
-        case CDF_Types::CDF_UCHAR:
+        case CDF_UCHAR:
             swap<true>(data.get<CDF_Types::CDF_UCHAR>(), shape);
             break;
-        case CDF_Types::CDF_UINT1:
+        case CDF_UINT1:
             swap<false>(data.get<unsigned char>(), shape);
             break;
-        case CDF_Types::CDF_UINT2:
+        case CDF_UINT2:
             swap<false>(data.get<uint16_t>(), shape);
             break;
-        case CDF_Types::CDF_UINT4:
+        case CDF_UINT4:
             swap<false>(data.get<uint32_t>(), shape);
             break;
-        case CDF_Types::CDF_INT2:
+        case CDF_INT2:
             swap<false>(data.get<int16_t>(), shape);
             break;
-        case CDF_Types::CDF_INT4:
+        case CDF_INT4:
             swap<false>(data.get<int32_t>(), shape);
             break;
-        case CDF_Types::CDF_INT8:
+        case CDF_INT8:
             swap<false>(data.get<int64_t>(), shape);
             break;
-        case CDF_Types::CDF_FLOAT:
-        case CDF_Types::CDF_REAL4:
+        case CDF_FLOAT:
+        case CDF_REAL4:
             swap<false>(data.get<float>(), shape);
             break;
-        case CDF_Types::CDF_DOUBLE:
-        case CDF_Types::CDF_REAL8:
+        case CDF_DOUBLE:
+        case CDF_REAL8:
             swap<false>(data.get<double>(), shape);
             break;
-        case CDF_Types::CDF_EPOCH:
+        case CDF_EPOCH:
             swap<false>(data.get<epoch>(), shape);
             break;
-        case CDF_Types::CDF_EPOCH16:
+        case CDF_EPOCH16:
             swap<false>(data.get<epoch16>(), shape);
             break;
-        case CDF_Types::CDF_TIME_TT2000:
+        case CDF_TIME_TT2000:
             swap<false>(data.get<tt2000_t>(), shape);
             break;
         default:

--- a/include/cdfpp/cdf-io/saving/records-saving.hpp
+++ b/include/cdfpp/cdf-io/saving/records-saving.hpp
@@ -112,13 +112,13 @@ struct variable_ctx
 template <typename... Ts>
 auto visit(const variable_ctx::values_records_t& values_records, Ts... lambdas)
 {
-    return std::visit(helpers::make_visitor(lambdas...), values_records);
+    return std::visit(helpers::Visitor { lambdas... }, values_records);
 }
 
 template <typename... Ts>
 auto visit(variable_ctx::values_records_t& values_records, Ts... lambdas)
 {
-    return std::visit(helpers::make_visitor(lambdas...), values_records);
+    return std::visit(helpers::Visitor { lambdas... }, values_records);
 }
 
 struct cdf_body

--- a/include/cdfpp/no_init_vector.hpp
+++ b/include/cdfpp/no_init_vector.hpp
@@ -68,59 +68,43 @@ public:
     }
 
 #if __has_include(<sys/mman.h>)
-    template <bool U = is_trivial_and_nothrow_default_constructible>
-    T* allocate(std::size_t pCount, const T* = 0, typename std::enable_if<U>::type* = 0)
+    T* allocate(std::size_t pCount)
     {
-        void* mem = 0;
-        auto bytes = sizeof(T) * pCount;
-        if (bytes >= 2 * page_size)
+        if constexpr (is_trivial_and_nothrow_default_constructible)
         {
-            if (::posix_memalign(&mem, page_size, sizeof(T) * pCount) != 0)
+            void* mem = 0;
+            auto bytes = sizeof(T) * pCount;
+            if (bytes >= 2 * page_size)
             {
-                throw std::bad_alloc(); // or something
-            }
+                if (::posix_memalign(&mem, page_size, sizeof(T) * pCount) != 0)
+                {
+                    throw std::bad_alloc();
+                }
 #ifdef MADV_HUGEPAGE
-            ::madvise(mem, pCount * sizeof(T), MADV_HUGEPAGE);
+                ::madvise(mem, pCount * sizeof(T), MADV_HUGEPAGE);
 #endif
-            // tell the kernel to start populating the pages
-            ::madvise(mem, pCount * sizeof(T), MADV_WILLNEED);
+                ::madvise(mem, pCount * sizeof(T), MADV_WILLNEED);
+            }
+            else
+            {
+                mem = ::malloc(bytes);
+                if (!mem)
+                    throw std::bad_alloc();
+            }
+            return reinterpret_cast<T*>(mem);
         }
         else
         {
-            mem = ::malloc(bytes);
-            if (!mem)
-                throw std::bad_alloc();
+            return A::allocate(pCount);
         }
-        //::memset(reinterpret_cast<char*>(mem),0x9e,bytes);
-        return reinterpret_cast<T*>(mem);
     }
 
-#if __cplusplus < 202002L
-    template <bool U = is_trivial_and_nothrow_default_constructible>
-    T* allocate(std::size_t pCount, const T* ptr = 0, typename std::enable_if<!U>::type* = 0)
+    void deallocate(T* ptr, std::size_t sz) noexcept(std::is_nothrow_default_constructible_v<T>)
     {
-        return A::allocate(pCount, ptr);
-    }
-#endif
-
-    template <bool U = is_trivial_and_nothrow_default_constructible>
-    T* allocate(std::size_t pCount, typename std::enable_if<!U>::type* = 0)
-    {
-        return A::allocate(pCount);
-    }
-
-    template <bool U = is_trivial_and_nothrow_default_constructible>
-    void deallocate(T* ptr, std::size_t, typename std::enable_if<U>::type* = 0) noexcept(
-        std::is_nothrow_default_constructible<T>::value)
-    {
-        ::free(ptr);
-    }
-
-    template <bool U = is_trivial_and_nothrow_default_constructible>
-    void deallocate(T* ptr, std::size_t sz, typename std::enable_if<!U>::type* = 0) noexcept(
-        std::is_nothrow_default_constructible<T>::value)
-    {
-        A::deallocate(ptr, sz);
+        if constexpr (is_trivial_and_nothrow_default_constructible)
+            ::free(ptr);
+        else
+            A::deallocate(ptr, sz);
     }
 #endif
 };
@@ -152,11 +136,3 @@ template <typename T>
     return v1 == v2;
 }
 
-namespace std
-{
-template <typename T>
-[[nodiscard]] size_t size(const no_init_vector<T>& v) noexcept
-{
-    return v.size();
-}
-}

--- a/include/cdfpp/nomap.hpp
+++ b/include/cdfpp/nomap.hpp
@@ -128,8 +128,6 @@ struct nomap
         return true;
     }
 
-    inline bool operator!=(const nomap& other) const { return !(*this == other); }
-
     [[nodiscard]] inline bool empty() const noexcept { return p_nodes.empty(); }
     [[nodiscard]] inline size_type size() const noexcept { return std::size(p_nodes); }
 

--- a/include/cdfpp/variable.hpp
+++ b/include/cdfpp/variable.hpp
@@ -137,9 +137,6 @@ struct Variable
             && other.attributes == attributes && other._data() == _data();
     }
 
-    inline bool operator!=(const Variable& other) const { return !(*this == other); }
-
-
     template <CDF_Types type>
     [[nodiscard]] decltype(auto) get()
     {

--- a/pycdfpp/attribute.hpp
+++ b/pycdfpp/attribute.hpp
@@ -119,87 +119,73 @@ using string_or_buffer_t = std::variant<std::string, std::vector<tt2000_t>, std:
 template <typename... Ts>
 auto visit(const py_cdf_attr_data_t& data, Ts... lambdas)
 {
-    return std::visit(helpers::make_visitor(lambdas...), data);
+    return std::visit(helpers::Visitor { lambdas... }, data);
 }
 
 template <typename... Ts>
 auto visit(py_cdf_attr_data_t& data, Ts... lambdas)
 {
-    return std::visit(helpers::make_visitor(lambdas...), data);
+    return std::visit(helpers::Visitor { lambdas... }, data);
 }
 
 template <typename... Ts>
 auto visit(const string_or_buffer_t& data, Ts... lambdas)
 {
-    return std::visit(helpers::make_visitor(lambdas...), data);
+    return std::visit(helpers::Visitor { lambdas... }, data);
 }
 
 template <typename... Ts>
 auto visit(string_or_buffer_t& data, Ts... lambdas)
 {
-    return std::visit(helpers::make_visitor(lambdas...), data);
+    return std::visit(helpers::Visitor { lambdas... }, data);
 }
 
 [[nodiscard]] inline py_cdf_attr_data_t to_py_cdf_data(const cdf::data_t& data)
 {
+    using enum cdf::CDF_Types;
     switch (data.type())
     {
-        case cdf::CDF_Types::CDF_BYTE:
-        case cdf::CDF_Types::CDF_INT1:
+        case CDF_BYTE:
+        case CDF_INT1:
             return data.get<int8_t>();
-            break;
-        case cdf::CDF_Types::CDF_UINT1:
+        case CDF_UINT1:
             return data.get<uint8_t>();
-            break;
-        case cdf::CDF_Types::CDF_INT2:
+        case CDF_INT2:
             return data.get<int16_t>();
-            break;
-        case cdf::CDF_Types::CDF_INT4:
+        case CDF_INT4:
             return data.get<int32_t>();
-            break;
-        case cdf::CDF_Types::CDF_INT8:
+        case CDF_INT8:
             return data.get<int64_t>();
-            break;
-        case cdf::CDF_Types::CDF_UINT2:
+        case CDF_UINT2:
             return data.get<uint16_t>();
-            break;
-        case cdf::CDF_Types::CDF_UINT4:
+        case CDF_UINT4:
             return data.get<uint32_t>();
-            break;
-        case cdf::CDF_Types::CDF_DOUBLE:
-        case cdf::CDF_Types::CDF_REAL8:
+        case CDF_DOUBLE:
+        case CDF_REAL8:
             return data.get<double>();
-            break;
-        case cdf::CDF_Types::CDF_FLOAT:
-        case cdf::CDF_Types::CDF_REAL4:
+        case CDF_FLOAT:
+        case CDF_REAL4:
             return data.get<float>();
-            break;
-        case cdf::CDF_Types::CDF_EPOCH:
+        case CDF_EPOCH:
             return data.get<epoch>();
-            break;
-        case cdf::CDF_Types::CDF_EPOCH16:
+        case CDF_EPOCH16:
             return data.get<epoch16>();
-            break;
-        case cdf::CDF_Types::CDF_TIME_TT2000:
+        case CDF_TIME_TT2000:
             return data.get<tt2000_t>();
-            break;
-        case cdf::CDF_Types::CDF_UCHAR:
+        case CDF_UCHAR:
         {
             auto v = data.get<cdf::CDF_Types::CDF_UCHAR>();
             return std::string(reinterpret_cast<const char*>(v.data()), std::size(v));
         }
-        break;
-        case cdf::CDF_Types::CDF_CHAR:
+        case CDF_CHAR:
         {
             auto v = data.get<char>();
             return std::string(v.data(), std::size(v));
         }
-        break;
         default:
             throw std::runtime_error { fmt::format(
                 "Unsupported CDF type {} ({})", cdf_type_str(data.type()),
                 static_cast<int>(data.type())) };
-            break;
     }
     return {};
 }
@@ -282,55 +268,41 @@ data_t to_attr_data_entry(const py::buffer& buffer)
 
 data_t to_attr_data_entry(const py::buffer& buffer, CDF_Types data_type)
 {
+    using enum CDF_Types;
     switch (data_type)
     {
-        case cdf::CDF_Types::CDF_INT1: // int8
-            return to_attr_data_entry<cdf::CDF_Types::CDF_INT1>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_INT2: // int16
-            return to_attr_data_entry<cdf::CDF_Types::CDF_INT2>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_INT4: // int32
-            return to_attr_data_entry<cdf::CDF_Types::CDF_INT4>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_INT8: // int64
-            return to_attr_data_entry<cdf::CDF_Types::CDF_INT8>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_UINT1: // uint8
-            return to_attr_data_entry<cdf::CDF_Types::CDF_UINT1>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_UINT2: // uint16
-            return to_attr_data_entry<cdf::CDF_Types::CDF_UINT2>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_UINT4: // uint32
-            return to_attr_data_entry<cdf::CDF_Types::CDF_UINT4>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_FLOAT: // float32
-            return to_attr_data_entry<cdf::CDF_Types::CDF_FLOAT>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_REAL4: // float32
-            return to_attr_data_entry<cdf::CDF_Types::CDF_REAL4>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_DOUBLE: // float64
-            return to_attr_data_entry<cdf::CDF_Types::CDF_DOUBLE>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_REAL8: // float64
-            return to_attr_data_entry<cdf::CDF_Types::CDF_REAL8>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_EPOCH: // epoch
-            return to_attr_data_entry<cdf::CDF_Types::CDF_EPOCH>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_EPOCH16: // epoch16
-            return to_attr_data_entry<cdf::CDF_Types::CDF_EPOCH16>(buffer);
-            break;
-        case cdf::CDF_Types::CDF_TIME_TT2000: // tt2000
-            return to_attr_data_entry<cdf::CDF_Types::CDF_TIME_TT2000>(buffer);
-            break;
+        case CDF_INT1:
+            return to_attr_data_entry<CDF_INT1>(buffer);
+        case CDF_INT2:
+            return to_attr_data_entry<CDF_INT2>(buffer);
+        case CDF_INT4:
+            return to_attr_data_entry<CDF_INT4>(buffer);
+        case CDF_INT8:
+            return to_attr_data_entry<CDF_INT8>(buffer);
+        case CDF_UINT1:
+            return to_attr_data_entry<CDF_UINT1>(buffer);
+        case CDF_UINT2:
+            return to_attr_data_entry<CDF_UINT2>(buffer);
+        case CDF_UINT4:
+            return to_attr_data_entry<CDF_UINT4>(buffer);
+        case CDF_FLOAT:
+            return to_attr_data_entry<CDF_FLOAT>(buffer);
+        case CDF_REAL4:
+            return to_attr_data_entry<CDF_REAL4>(buffer);
+        case CDF_DOUBLE:
+            return to_attr_data_entry<CDF_DOUBLE>(buffer);
+        case CDF_REAL8:
+            return to_attr_data_entry<CDF_REAL8>(buffer);
+        case CDF_EPOCH:
+            return to_attr_data_entry<CDF_EPOCH>(buffer);
+        case CDF_EPOCH16:
+            return to_attr_data_entry<CDF_EPOCH16>(buffer);
+        case CDF_TIME_TT2000:
+            return to_attr_data_entry<CDF_TIME_TT2000>(buffer);
         default:
             throw std::invalid_argument { fmt::format(
                 "Unsupported CDF type {} ({}) for buffer attribute",
                 cdf_type_str(data_type), static_cast<int>(data_type)) };
-            break;
     }
 }
 

--- a/pycdfpp/chrono.hpp
+++ b/pycdfpp/chrono.hpp
@@ -321,34 +321,28 @@ template <typename time_t>
 
 [[nodiscard]] inline py::object to_datetime64(const Variable& input)
 {
+    using enum cdf::CDF_Types;
     auto result = _details::fast_allocate_array<uint64_t>(input.shape());
     auto out_ptr = static_cast<int64_t*>(result.request(true).ptr);
     const auto size = static_cast<std::size_t>(result.size());
     switch (input.type())
     {
-        case cdf::CDF_Types::CDF_EPOCH:
-        {
+        case CDF_EPOCH:
             to_datetime64(
                 std::span { input.get<cdf::CDF_Types::CDF_EPOCH>().data(), size }, out_ptr);
-        }
-        break;
-        case cdf::CDF_Types::CDF_EPOCH16:
-        {
+            break;
+        case CDF_EPOCH16:
             to_datetime64(
                 std::span { input.get<cdf::CDF_Types::CDF_EPOCH16>().data(), size }, out_ptr);
-        }
-        break;
-        case cdf::CDF_Types::CDF_TIME_TT2000:
-        {
+            break;
+        case CDF_TIME_TT2000:
             to_datetime64(
                 std::span { input.get<cdf::CDF_Types::CDF_TIME_TT2000>().data(), size }, out_ptr);
-        }
-        break;
+            break;
         default:
             throw std::invalid_argument(fmt::format(
                 "to_datetime64 requires a CDF time variable (CDF_EPOCH, CDF_EPOCH16, or CDF_TIME_TT2000), got {}",
                 cdf_type_str(input.type())));
-            break;
     }
     return result.attr("view")("datetime64[ns]");
 }
@@ -356,31 +350,22 @@ template <typename time_t>
 
 [[nodiscard]] py::list to_datetime(const Variable& input)
 {
+    using enum cdf::CDF_Types;
     switch (input.type())
     {
-        case cdf::CDF_Types::CDF_EPOCH:
-        {
+        case CDF_EPOCH:
             return _details::ranges::transform<py::list, epoch>(
                 input, static_cast<PyObject* (*)(const epoch)>(_details::to_datetime<epoch>));
-        }
-        break;
-        case cdf::CDF_Types::CDF_EPOCH16:
-        {
+        case CDF_EPOCH16:
             return _details::ranges::transform<py::list, epoch16>(
                 input, static_cast<PyObject* (*)(const epoch16)>(_details::to_datetime<epoch16>));
-        }
-        break;
-        case cdf::CDF_Types::CDF_TIME_TT2000:
-        {
+        case CDF_TIME_TT2000:
             return _details::ranges::transform<py::list, tt2000_t>(
                 input, static_cast<PyObject* (*)(const tt2000_t)>(_details::to_datetime<tt2000_t>));
-        }
-        break;
         default:
             throw std::invalid_argument(fmt::format(
                 "to_datetime requires a CDF time variable (CDF_EPOCH, CDF_EPOCH16, or CDF_TIME_TT2000), got {}",
                 cdf_type_str(input.type())));
-            break;
     }
     return py::list {};
 }

--- a/pycdfpp/data_types.hpp
+++ b/pycdfpp/data_types.hpp
@@ -226,29 +226,30 @@ struct analyze_context
 
 [[nodiscard]] constexpr BestTypeId to_best_type_id(const CDF_Types& t)
 {
+    using enum CDF_Types;
     switch (t)
     {
-        case CDF_Types::CDF_UCHAR:
-        case CDF_Types::CDF_CHAR:
+        case CDF_UCHAR:
+        case CDF_CHAR:
             return BestTypeId::String;
-        case CDF_Types::CDF_TIME_TT2000:
+        case CDF_TIME_TT2000:
             return BestTypeId::DateTime;
-        case CDF_Types::CDF_DOUBLE:
-        case CDF_Types::CDF_FLOAT:
+        case CDF_DOUBLE:
+        case CDF_FLOAT:
             return BestTypeId::Float;
-        case CDF_Types::CDF_INT1:
+        case CDF_INT1:
             return BestTypeId::Int8;
-        case CDF_Types::CDF_INT2:
+        case CDF_INT2:
             return BestTypeId::Int16;
-        case CDF_Types::CDF_INT4:
+        case CDF_INT4:
             return BestTypeId::Int32;
-        case CDF_Types::CDF_INT8:
+        case CDF_INT8:
             return BestTypeId::Int64;
-        case CDF_Types::CDF_UINT1:
+        case CDF_UINT1:
             return BestTypeId::UInt8;
-        case CDF_Types::CDF_UINT2:
+        case CDF_UINT2:
             return BestTypeId::UInt16;
-        case CDF_Types::CDF_UINT4:
+        case CDF_UINT4:
             return BestTypeId::UInt32;
         default:
             return BestTypeId::None;
@@ -257,47 +258,42 @@ struct analyze_context
 
 [[nodiscard]] constexpr bool are_compatible_types(const CDF_Types& dest, const CDF_Types& source)
 {
+    using enum CDF_Types;
     switch (dest)
     {
-        case CDF_Types::CDF_UCHAR:
-        case CDF_Types::CDF_CHAR:
-            return (source == CDF_Types::CDF_UCHAR) || (source == CDF_Types::CDF_CHAR);
-        case CDF_Types::CDF_TIME_TT2000:
-        case CDF_Types::CDF_EPOCH:
-        case CDF_Types::CDF_EPOCH16:
-            return (source == CDF_Types::CDF_TIME_TT2000) || (source == CDF_Types::CDF_EPOCH)
-                || (source == CDF_Types::CDF_EPOCH16);
-        case CDF_Types::CDF_DOUBLE:
-        case CDF_Types::CDF_REAL8:
-            return helpers::rt_is_in(source, CDF_Types::CDF_DOUBLE, CDF_Types::CDF_REAL8,
-                CDF_Types::CDF_FLOAT, CDF_Types::CDF_INT1, CDF_Types::CDF_INT2, CDF_Types::CDF_INT4,
-                CDF_Types::CDF_UINT1, CDF_Types::CDF_UINT2, CDF_Types::CDF_UINT4);
-        case CDF_Types::CDF_FLOAT:
-        case CDF_Types::CDF_REAL4:
-            return helpers::rt_is_in(source, CDF_Types::CDF_FLOAT, CDF_Types::CDF_REAL4,
-                CDF_Types::CDF_INT1, CDF_Types::CDF_INT2, CDF_Types::CDF_UINT1,
-                CDF_Types::CDF_UINT2);
-        case CDF_Types::CDF_INT8:
-            return helpers::rt_is_in(source, CDF_Types::CDF_INT8, CDF_Types::CDF_INT4,
-                CDF_Types::CDF_INT2, CDF_Types::CDF_INT1, CDF_Types::CDF_UINT4,
-                CDF_Types::CDF_UINT2, CDF_Types::CDF_UINT1);
-        case CDF_Types::CDF_INT4:
-            return helpers::rt_is_in(source, CDF_Types::CDF_INT4, CDF_Types::CDF_INT2,
-                CDF_Types::CDF_INT1, CDF_Types::CDF_UINT2, CDF_Types::CDF_UINT1);
-        case CDF_Types::CDF_INT2:
+        case CDF_UCHAR:
+        case CDF_CHAR:
+            return (source == CDF_UCHAR) || (source == CDF_CHAR);
+        case CDF_TIME_TT2000:
+        case CDF_EPOCH:
+        case CDF_EPOCH16:
+            return (source == CDF_TIME_TT2000) || (source == CDF_EPOCH)
+                || (source == CDF_EPOCH16);
+        case CDF_DOUBLE:
+        case CDF_REAL8:
+            return helpers::rt_is_in(source, CDF_DOUBLE, CDF_REAL8, CDF_FLOAT, CDF_INT1, CDF_INT2,
+                CDF_INT4, CDF_UINT1, CDF_UINT2, CDF_UINT4);
+        case CDF_FLOAT:
+        case CDF_REAL4:
             return helpers::rt_is_in(
-                source, CDF_Types::CDF_INT2, CDF_Types::CDF_INT1, CDF_Types::CDF_UINT1);
-        case CDF_Types::CDF_INT1:
-        case CDF_Types::CDF_BYTE:
-            return source == CDF_Types::CDF_INT1;
-        case CDF_Types::CDF_UINT4:
+                source, CDF_FLOAT, CDF_REAL4, CDF_INT1, CDF_INT2, CDF_UINT1, CDF_UINT2);
+        case CDF_INT8:
             return helpers::rt_is_in(
-                source, CDF_Types::CDF_UINT4, CDF_Types::CDF_UINT2, CDF_Types::CDF_UINT1);
-        case CDF_Types::CDF_UINT2:
-            return helpers::rt_is_in(source, CDF_Types::CDF_UINT2, CDF_Types::CDF_UINT1);
-        case CDF_Types::CDF_UINT1:
-            return source == CDF_Types::CDF_UINT1;
-        case CDF_Types::CDF_NONE:
+                source, CDF_INT8, CDF_INT4, CDF_INT2, CDF_INT1, CDF_UINT4, CDF_UINT2, CDF_UINT1);
+        case CDF_INT4:
+            return helpers::rt_is_in(source, CDF_INT4, CDF_INT2, CDF_INT1, CDF_UINT2, CDF_UINT1);
+        case CDF_INT2:
+            return helpers::rt_is_in(source, CDF_INT2, CDF_INT1, CDF_UINT1);
+        case CDF_INT1:
+        case CDF_BYTE:
+            return source == CDF_INT1;
+        case CDF_UINT4:
+            return helpers::rt_is_in(source, CDF_UINT4, CDF_UINT2, CDF_UINT1);
+        case CDF_UINT2:
+            return helpers::rt_is_in(source, CDF_UINT2, CDF_UINT1);
+        case CDF_UINT1:
+            return source == CDF_UINT1;
+        case CDF_NONE:
             return true;
         default:
             break;


### PR DESCRIPTION
## Summary
- Add `using enum` to all large switch blocks, removing ~200 lines of qualifier noise
- Replace `std::enable_if` with `requires` clauses in cdf-data.hpp, buffers.hpp, and no_init_vector.hpp
- Remove redundant `operator!=` definitions (C++20 synthesizes from `operator==`)
- Replace `Visitor` constructor + `make_visitor` helper with C++20 aggregate CTAD
- Default `operator==` on `tt2000_t`, `epoch`, `epoch16` aggregates
- Remove UB `namespace std` injection from no_init_vector.hpp
- Consolidate no_init_vector allocator SFINAE overloads into single functions with `if constexpr`

## Test plan
- [x] Full rebuild passes (55/55 targets)
- [x] All 18 tests pass (full_corpus excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)