### PR TITLE
Modernize reflection and type dispatch with C++20 idioms

### DIFF
--- a/include/cdfpp/cdf-data.hpp
+++ b/include/cdfpp/cdf-data.hpp
@@ -315,38 +315,17 @@ template <CDF_Types _type, typename endianness_t, bool latin1_to_utf8_conv>
 template <bool iso_8859_1_to_utf8>
 [[nodiscard]] inline data_t load_values(data_t&& data, cdf_encoding encoding) noexcept
 {
-#define DATA_FROM_T(_type)                                                                         \
-    case CDF_Types::_type:                                                                         \
-        if (endianness::is_big_endian_encoding(encoding))                                          \
-            return load_values<CDF_Types::_type, endianness::big_endian_t, iso_8859_1_to_utf8>(    \
-                std::move(data));                                                                  \
-        return load_values<CDF_Types::_type, endianness::little_endian_t, iso_8859_1_to_utf8>(     \
-            std::move(data));
-
-
-    switch (data.type())
-    {
-        DATA_FROM_T(CDF_FLOAT)
-        DATA_FROM_T(CDF_DOUBLE)
-        DATA_FROM_T(CDF_REAL4)
-        DATA_FROM_T(CDF_REAL8)
-        DATA_FROM_T(CDF_EPOCH)
-        DATA_FROM_T(CDF_EPOCH16)
-        DATA_FROM_T(CDF_TIME_TT2000)
-        DATA_FROM_T(CDF_CHAR)
-        DATA_FROM_T(CDF_UCHAR)
-        DATA_FROM_T(CDF_INT1)
-        DATA_FROM_T(CDF_INT2)
-        DATA_FROM_T(CDF_INT4)
-        DATA_FROM_T(CDF_INT8)
-        DATA_FROM_T(CDF_UINT1)
-        DATA_FROM_T(CDF_UINT2)
-        DATA_FROM_T(CDF_UINT4)
-        DATA_FROM_T(CDF_BYTE)
-        case CDF_Types::CDF_NONE:
-            return {};
-    }
-    return {};
+    if (data.type() == CDF_Types::CDF_NONE)
+        return {};
+    return cdf_type_dispatch(data.type(),
+        [&]<CDF_Types t>()
+        {
+            if (endianness::is_big_endian_encoding(encoding))
+                return load_values<t, endianness::big_endian_t, iso_8859_1_to_utf8>(
+                    std::move(data));
+            return load_values<t, endianness::little_endian_t, iso_8859_1_to_utf8>(
+                std::move(data));
+        });
 }
 
 template <CDF_Types _type>
@@ -360,33 +339,11 @@ template <CDF_Types _type>
 
 [[nodiscard]] inline data_t new_data_container(std::size_t bytes_len, CDF_Types _type)
 {
-#define DC_FROM_T(_type)                                                                           \
-    case CDF_Types::_type:                                                                         \
-        return data_t { new_cdf_values_container<CDF_Types::_type>(bytes_len), CDF_Types::_type };
-
-    switch (_type)
-    {
-        DC_FROM_T(CDF_FLOAT)
-        DC_FROM_T(CDF_DOUBLE)
-        DC_FROM_T(CDF_REAL4)
-        DC_FROM_T(CDF_REAL8)
-        DC_FROM_T(CDF_EPOCH)
-        DC_FROM_T(CDF_EPOCH16)
-        DC_FROM_T(CDF_TIME_TT2000)
-        DC_FROM_T(CDF_CHAR)
-        DC_FROM_T(CDF_UCHAR)
-        DC_FROM_T(CDF_INT1)
-        DC_FROM_T(CDF_INT2)
-        DC_FROM_T(CDF_INT4)
-        DC_FROM_T(CDF_INT8)
-        DC_FROM_T(CDF_UINT1)
-        DC_FROM_T(CDF_UINT2)
-        DC_FROM_T(CDF_UINT4)
-        DC_FROM_T(CDF_BYTE)
-        case CDF_Types::CDF_NONE:
-            return {};
-    }
-    return {};
+    if (_type == CDF_Types::CDF_NONE)
+        return {};
+    return cdf_type_dispatch(_type,
+        [&]<CDF_Types t>()
+        { return data_t { new_cdf_values_container<t>(bytes_len), t }; });
 }
 
 

--- a/include/cdfpp/cdf-enums.hpp
+++ b/include/cdfpp/cdf-enums.hpp
@@ -28,6 +28,7 @@
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
+#include <string_view>
 #include <type_traits>
 
 #include "cdf-helpers.hpp"
@@ -280,80 +281,52 @@ constexpr auto from_cdf_type()
         return epoch16 {};
 }
 
-[[nodiscard]] inline std::size_t cdf_type_size(CDF_Types type)
+struct cdf_type_info
 {
-    using enum CDF_Types;
-    switch (type)
+    CDF_Types type;
+    std::size_t size;
+    std::string_view name;
+};
+
+// clang-format off
+inline constexpr cdf_type_info cdf_type_table[] = {
+    {CDF_Types::CDF_NONE,        0,  "CDF_NONE"},
+    {CDF_Types::CDF_INT1,        1,  "CDF_INT1"},
+    {CDF_Types::CDF_INT2,        2,  "CDF_INT2"},
+    {CDF_Types::CDF_INT4,        4,  "CDF_INT4"},
+    {CDF_Types::CDF_INT8,        8,  "CDF_INT8"},
+    {CDF_Types::CDF_UINT1,       1,  "CDF_UINT1"},
+    {CDF_Types::CDF_UINT2,       2,  "CDF_UINT2"},
+    {CDF_Types::CDF_UINT4,       4,  "CDF_UINT4"},
+    {CDF_Types::CDF_BYTE,        1,  "CDF_BYTE"},
+    {CDF_Types::CDF_REAL4,       4,  "CDF_REAL4"},
+    {CDF_Types::CDF_REAL8,       8,  "CDF_REAL8"},
+    {CDF_Types::CDF_FLOAT,       4,  "CDF_FLOAT"},
+    {CDF_Types::CDF_DOUBLE,      8,  "CDF_DOUBLE"},
+    {CDF_Types::CDF_EPOCH,       8,  "CDF_EPOCH"},
+    {CDF_Types::CDF_EPOCH16,     16, "CDF_EPOCH16"},
+    {CDF_Types::CDF_TIME_TT2000, 8,  "CDF_TIME_TT2000"},
+    {CDF_Types::CDF_CHAR,        1,  "CDF_CHAR"},
+    {CDF_Types::CDF_UCHAR,       1,  "CDF_UCHAR"},
+};
+// clang-format on
+
+[[nodiscard]] constexpr std::size_t cdf_type_size(CDF_Types type) noexcept
+{
+    for (const auto& info : cdf_type_table)
     {
-        case CDF_NONE:
-            return 0;
-        case CDF_INT1:
-        case CDF_UINT1:
-        case CDF_BYTE:
-        case CDF_CHAR:
-        case CDF_UCHAR:
-            return 1;
-        case CDF_INT2:
-        case CDF_UINT2:
-            return 2;
-        case CDF_INT4:
-        case CDF_UINT4:
-        case CDF_FLOAT:
-        case CDF_REAL4:
-            return 4;
-        case CDF_INT8:
-        case CDF_REAL8:
-        case CDF_DOUBLE:
-        case CDF_EPOCH:
-        case CDF_TIME_TT2000:
-            return 8;
-        case CDF_EPOCH16:
-            return 16;
+        if (info.type == type)
+            return info.size;
     }
     return 0;
 }
 
-[[nodiscard]] inline std::string cdf_type_str(CDF_Types type) noexcept
+[[nodiscard]] constexpr std::string_view cdf_type_str(CDF_Types type) noexcept
 {
-    using enum CDF_Types;
-    switch (type)
+    for (const auto& info : cdf_type_table)
     {
-        case CDF_NONE:
-            return "CDF_NONE";
-        case CDF_INT1:
-            return "CDF_INT1";
-        case CDF_UINT1:
-            return "CDF_UINT1";
-        case CDF_BYTE:
-            return "CDF_BYTE";
-        case CDF_CHAR:
-            return "CDF_CHAR";
-        case CDF_UCHAR:
-            return "CDF_UCHAR";
-        case CDF_INT2:
-            return "CDF_INT2";
-        case CDF_UINT2:
-            return "CDF_UINT2";
-        case CDF_INT4:
-            return "CDF_INT4";
-        case CDF_UINT4:
-            return "CDF_UINT4";
-        case CDF_FLOAT:
-            return "CDF_FLOAT";
-        case CDF_REAL4:
-            return "CDF_REAL4";
-        case CDF_INT8:
-            return "CDF_INT8";
-        case CDF_REAL8:
-            return "CDF_REAL8";
-        case CDF_DOUBLE:
-            return "CDF_DOUBLE";
-        case CDF_TIME_TT2000:
-            return "CDF_TIME_TT2000";
-        case CDF_EPOCH:
-            return "CDF_EPOCH";
-        case CDF_EPOCH16:
-            return "CDF_EPOCH16";
+        if (info.type == type)
+            return info.name;
     }
     return "unknown type";
 }

--- a/include/cdfpp/cdf-helpers.hpp
+++ b/include/cdfpp/cdf-helpers.hpp
@@ -55,13 +55,10 @@ namespace helpers
     }
 
     template <typename ref_type, typename... types>
-    struct is_any_of : std::integral_constant<bool,(std::is_same_v<ref_type, types> || ...)>{};
+    concept any_of = (std::is_same_v<ref_type, types> || ...);
 
     template <typename ref_type, typename... types>
-    using is_any_of_t = typename is_any_of<ref_type,types...>::type;
-
-    template <typename ref_type, typename... types>
-    inline constexpr bool is_any_of_v = is_any_of<ref_type,types...>::value;
+    inline constexpr bool is_any_of_v = any_of<ref_type, types...>;
 
     constexpr bool contains(const std::string& str, const auto& substr)
     {

--- a/include/cdfpp/cdf-io/majority-swap.hpp
+++ b/include/cdfpp/cdf-io/majority-swap.hpp
@@ -174,56 +174,13 @@ void swap(data_t& data, const shape_t& shape)
 
 void swap(data_t& data, const no_init_vector<uint32_t>& shape)
 {
-    using enum CDF_Types;
-    switch (data.type())
-    {
-        case CDF_BYTE:
-        case CDF_INT1:
-            swap<false>(data.get<int8_t>(), shape);
-            break;
-        case CDF_CHAR:
-            swap<true>(data.get<CDF_Types::CDF_CHAR>(), shape);
-            break;
-        case CDF_UCHAR:
-            swap<true>(data.get<CDF_Types::CDF_UCHAR>(), shape);
-            break;
-        case CDF_UINT1:
-            swap<false>(data.get<unsigned char>(), shape);
-            break;
-        case CDF_UINT2:
-            swap<false>(data.get<uint16_t>(), shape);
-            break;
-        case CDF_UINT4:
-            swap<false>(data.get<uint32_t>(), shape);
-            break;
-        case CDF_INT2:
-            swap<false>(data.get<int16_t>(), shape);
-            break;
-        case CDF_INT4:
-            swap<false>(data.get<int32_t>(), shape);
-            break;
-        case CDF_INT8:
-            swap<false>(data.get<int64_t>(), shape);
-            break;
-        case CDF_FLOAT:
-        case CDF_REAL4:
-            swap<false>(data.get<float>(), shape);
-            break;
-        case CDF_DOUBLE:
-        case CDF_REAL8:
-            swap<false>(data.get<double>(), shape);
-            break;
-        case CDF_EPOCH:
-            swap<false>(data.get<epoch>(), shape);
-            break;
-        case CDF_EPOCH16:
-            swap<false>(data.get<epoch16>(), shape);
-            break;
-        case CDF_TIME_TT2000:
-            swap<false>(data.get<tt2000_t>(), shape);
-            break;
-        default:
-            break;
-    }
+    if (data.type() == CDF_Types::CDF_NONE)
+        return;
+    cdf_type_dispatch(data.type(),
+        [&]<CDF_Types t>()
+        {
+            constexpr bool is_str = is_cdf_string_type(t);
+            swap<is_str>(data.get<t>(), shape);
+        });
 }
 }

--- a/include/cdfpp/cdf-io/reflection.hpp
+++ b/include/cdfpp/cdf-io/reflection.hpp
@@ -27,9 +27,7 @@
 #include <type_traits>
 #include <utility>
 
-/*
- * see https://stackoverflow.com/questions/39768517/structured-bindings-width/39779537#39779537
- */
+// https://stackoverflow.com/questions/39768517/structured-bindings-width/39779537#39779537
 
 namespace details
 {
@@ -39,20 +37,18 @@ struct anything
     operator T() const;
 };
 
-
-template <class T, class Is, class = void>
-struct _can_construct_with_N : std::false_type
+template <class T, std::size_t N>
+consteval bool can_construct_with_n()
 {
-};
-
-template <class T, std::size_t... Is>
-struct _can_construct_with_N<T, std::index_sequence<Is...>,
-    std::void_t<decltype(T { (void(Is), anything {})... })>> : std::true_type
-{
-};
+    return []<std::size_t... Is>(std::index_sequence<Is...>) {
+        return requires { T { (void(Is), anything {})... }; };
+    }(std::make_index_sequence<N> {});
+}
 
 template <class T, std::size_t N>
-using can_construct_with_N = _can_construct_with_N<T, std::make_index_sequence<N>>;
+struct can_construct_with_N : std::bool_constant<can_construct_with_n<T, N>()>
+{
+};
 
 
 template <std::size_t Min, std::size_t Range, template <std::size_t N> class target>

--- a/include/cdfpp/cdf-io/special-fields.hpp
+++ b/include/cdfpp/cdf-io/special-fields.hpp
@@ -25,6 +25,7 @@
 ----------------------------------------------------------------------------*/
 #pragma once
 #include "../no_init_vector.hpp"
+#include <concepts>
 #include <cstddef>
 #include <string>
 #include <vector>
@@ -36,20 +37,15 @@ struct string_field
     std::string value;
 };
 
-template <typename T, typename = void>
-struct is_string_field : std::false_type
-{
-};
-
 template <typename T>
-struct is_string_field<T, decltype(std::is_same_v<string_field<T::max_len>, T>, void())>
-        : std::is_same<string_field<T::max_len>, T>
-{
+concept string_field_c = requires {
+    { T::max_len } -> std::convertible_to<std::size_t>;
+    requires std::same_as<T, string_field<T::max_len>>;
 };
 
 template <typename T>
 static inline constexpr bool is_string_field_v
-    = is_string_field<std::remove_cv_t<std::remove_reference_t<T>>>::value;
+    = string_field_c<std::remove_cv_t<std::remove_reference_t<T>>>;
 
 
 template <typename T, std::size_t _index = 0>
@@ -66,19 +62,13 @@ struct unused_field
     T value;
 };
 
-
-template <typename T, typename = void>
-struct is_table_field : std::false_type
-{
-};
-
 template <typename T>
-struct is_table_field<T,
-    decltype(std::is_same_v<table_field<typename T::value_type, T::index>, T>, void())>
-        : std::is_same<table_field<typename T::value_type, T::index>, T>
-{
+concept table_field_c = requires {
+    typename T::value_type;
+    { T::index } -> std::convertible_to<std::size_t>;
+    requires std::same_as<T, table_field<typename T::value_type, T::index>>;
 };
 
 template <typename T>
 static inline constexpr bool is_table_field_v
-    = is_table_field<std::remove_cv_t<std::remove_reference_t<T>>>::value;
+    = table_field_c<std::remove_cv_t<std::remove_reference_t<T>>>;


### PR DESCRIPTION
## Summary
- Replace `DATA_FROM_T` / `DC_FROM_T` macros in `cdf-data.hpp` with `cdf_type_dispatch()` calls
- Consolidate `cdf_type_size()` and `cdf_type_str()` into a single `constexpr` lookup table (`cdf_type_table[]`)
- Replace 50-line type switch in `majority-swap.hpp` with `cdf_type_dispatch()`
- Replace SFINAE traits in `special-fields.hpp` with `string_field_c` / `table_field_c` concepts
- Replace `std::void_t` SFINAE in `reflection.hpp` with `consteval` + `requires` expression
- Replace `is_any_of` struct trait with `any_of` concept in `cdf-helpers.hpp`

Net: -214 / +84 lines across 6 files, no behavior changes.

## Test plan
- [x] All 18 meson tests pass locally (Linux, GCC)
- [x] Benchmarks (chrono, RLE, file_reader) show no regressions vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)