### PR TITLE
Fix force flag ignored in Variable.set_values

### DIFF
--- a/pycdfpp/variable.hpp
+++ b/pycdfpp/variable.hpp
@@ -612,7 +612,9 @@ void def_variable_wrapper(T& mod)
                         "will raise an exception in future versions.",
                         PyExc_DeprecationWarning, 3);
                 }
-                set_values(var, ensure_utf8(values), data_type ? data_type : var.type());
+                auto effective_type = data_type ? data_type
+                    : (force ? std::nullopt : std::optional { var.type() });
+                set_values(var, ensure_utf8(values), effective_type, force);
             },
             py::arg("values").noconvert(), py::arg("data_type") = std::nullopt,
             py::arg("force") = false)
@@ -628,7 +630,9 @@ void def_variable_wrapper(T& mod)
                         "will raise an exception in future versions.",
                         PyExc_DeprecationWarning, 3);
                 }
-                set_values(var, values, data_type ? data_type : var.type());
+                auto effective_type = data_type ? data_type
+                    : (force ? std::nullopt : std::optional { var.type() });
+                set_values(var, values, effective_type, force);
             },
             py::arg("values").noconvert(), py::arg("data_type") = std::nullopt,
             py::arg("force") = false)
@@ -644,7 +648,9 @@ void def_variable_wrapper(T& mod)
                         "will raise an exception in future versions.",
                         PyExc_DeprecationWarning, 3);
                 }
-                set_values(var, values, data_type ? data_type : var.type());
+                auto effective_type = data_type ? data_type
+                    : (force ? std::nullopt : std::optional { var.type() });
+                set_values(var, values, effective_type, force);
             },
             py::arg("values").noconvert(), py::arg("data_type") = std::nullopt,
             py::arg("force") = false)

--- a/tests/python_variable_set_values/test.py
+++ b/tests/python_variable_set_values/test.py
@@ -208,6 +208,69 @@ class PycdfVariableSetValues(unittest.TestCase):
         cdf2["var2"].set_values(cdf1["var1"])
         self.assertTrue(np.array_equal(pycdfpp.to_datetime64(cdf2["var2"]), values))
 
+class PycdfVariableSetValuesForce(unittest.TestCase):
+    """Reproducer for https://github.com/SciQLop/CDFpp/issues/76"""
+
+    def test_force_different_shape(self):
+        cdf = pycdfpp.CDF()
+        cdf.add_variable("data", values=np.zeros((1, 64), dtype=np.float64))
+        cdf["data"].set_values(np.ones((1, 51), dtype=np.float64), force=True)
+        self.assertEqual(cdf["data"].shape, (1, 51))
+        self.assertTrue(np.all(cdf["data"].values == 1.0))
+
+    def test_force_different_type_numpy(self):
+        cdf = pycdfpp.CDF()
+        cdf.add_variable("data", values=np.zeros(10, dtype=np.float64))
+        cdf["data"].set_values(np.arange(20, dtype=np.int32), force=True)
+        self.assertEqual(cdf["data"].shape, (20,))
+        self.assertEqual(cdf["data"].type, pycdfpp.DataType.CDF_INT4)
+        self.assertTrue(np.array_equal(cdf["data"].values, np.arange(20, dtype=np.int32)))
+
+    def test_force_different_type_and_shape_numpy(self):
+        cdf = pycdfpp.CDF()
+        cdf.add_variable("data", values=np.zeros((3, 4), dtype=np.float64))
+        cdf["data"].set_values(np.ones((2, 5), dtype=np.int16), force=True)
+        self.assertEqual(cdf["data"].shape, (2, 5))
+        self.assertEqual(cdf["data"].type, pycdfpp.DataType.CDF_INT2)
+
+    def test_force_different_type_list(self):
+        cdf = pycdfpp.CDF()
+        cdf.add_variable("data", values=np.zeros(5, dtype=np.float64))
+        cdf["data"].set_values([1, 2, 3], force=True)
+        self.assertEqual(cdf["data"].shape, (3,))
+
+    def test_force_different_shape_list(self):
+        cdf = pycdfpp.CDF()
+        cdf.add_variable("data", values=np.zeros((2, 3), dtype=np.float64))
+        cdf["data"].set_values([[1.0, 2.0]], force=True)
+        self.assertEqual(cdf["data"].shape, (1, 2))
+
+    def test_force_with_explicit_data_type(self):
+        cdf = pycdfpp.CDF()
+        cdf.add_variable("data", values=np.zeros(10, dtype=np.float64))
+        cdf["data"].set_values(
+            np.arange(5, dtype=np.float32),
+            data_type=pycdfpp.DataType.CDF_FLOAT, force=True)
+        self.assertEqual(cdf["data"].type, pycdfpp.DataType.CDF_FLOAT)
+        self.assertEqual(cdf["data"].shape, (5,))
+
+    def test_force_from_variable_different_type(self):
+        cdf = pycdfpp.CDF()
+        cdf.add_variable("src", values=np.arange(5, dtype=np.int32))
+        cdf.add_variable("dst", values=np.zeros(10, dtype=np.float64))
+        cdf["dst"].set_values(cdf["src"], force=True)
+        self.assertEqual(cdf["dst"].type, pycdfpp.DataType.CDF_INT4)
+        self.assertTrue(np.array_equal(cdf["dst"].values, np.arange(5, dtype=np.int32)))
+
+    def test_without_force_still_rejects_incompatible(self):
+        cdf = pycdfpp.CDF()
+        cdf.add_variable("data", values=np.zeros(10, dtype=np.float64))
+        with self.assertRaises(ValueError):
+            cdf["data"].set_values(np.arange(20, dtype=np.int32))
+        with self.assertRaises(ValueError):
+            cdf["data"].set_values(np.ones((2, 5), dtype=np.float64))
+
+
 class PycdfFilterCDF(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Summary

Fixes #76.

- The `force` parameter in `Variable.set_values()` was accepted by the pybind11 lambdas but **never forwarded** to the internal `set_values()` function, so type/shape compatibility checks always ran regardless of `force=True`.
- Additionally, when `force=True` without an explicit `data_type`, the old variable's type was used for conversion dispatch, causing itemsize mismatches (e.g. trying to interpret a 4-byte int32 buffer as 8-byte double).
- Added 8 test cases covering: different shape, different type (numpy/list), combined type+shape change, explicit data_type override, variable-to-variable force copy, and a regression guard confirming `force=False` still rejects incompatible values.

## Test plan

- [x] All 36 tests in `tests/python_variable_set_values/test.py` pass (8 new + 28 existing)
- [x] Exact reproducer from #76 (`set_values(np.arange(20, dtype=np.int32), force=True)` on a float64 variable) now works
- [x] NRV shape change reproducer (`(1,64)` → `(1,51)`) now works

🤖 Generated with [Claude Code](https://claude.com/claude-code)