### PR TITLE
WASM wrapper rewrite with demo UI and GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,11 +10,6 @@ on:
       - '.github/workflows/gh-pages.yml'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: pages
   cancel-in-progress: true
@@ -22,6 +17,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -58,6 +55,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,66 @@
+name: Deploy WASM demo to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'wacdfpp/**'
+      - 'include/**'
+      - 'meson.build'
+      - '.github/workflows/gh-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 4.0.9
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install meson and ninja
+        run: pip install meson ninja
+
+      - name: Configure
+        run: >
+          meson setup build_wasm
+          --cross-file wacdfpp/wasm.txt
+          -Ddisable_python_wrapper=true
+          -Dwith_experimental_wasm=true
+
+      - name: Build
+        run: ninja -C build_wasm
+
+      - name: Prepare pages
+        run: |
+          mkdir -p _site
+          cp build_wasm/wacdfpp/cdfpp.js _site/
+          cp build_wasm/wacdfpp/cdfpp.wasm _site/
+          cp build_wasm/wacdfpp/wacdfpp.html _site/index.html
+
+      - uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: Deploy WASM demo to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - 'wacdfpp/**'
       - 'include/**'

--- a/meson.build
+++ b/meson.build
@@ -52,7 +52,11 @@ endif
 pybind11_dep = dependency('pybind11')
 hedley_dep = dependency('hedley')
 fmt_dep = dependency('fmt')
-xsimd_dep = dependency('xsimd')
+if target_machine.cpu_family() == 'x86_64'
+    xsimd_dep = dependency('xsimd')
+else
+    xsimd_dep = dependency('', required: false)
+endif
 
 if build_machine.system() == 'windows'
     link_args = ['-static-libstdc++','-static-libgcc','-static']
@@ -272,11 +276,14 @@ summary({
     'Architecture': target_machine.cpu_family(),
         }, section: 'Compilers')
 
-summary({
+deps_summary = {
     'Hedley': hedley_dep.version(),
     'fmt': fmt_dep.version(),
-    'xsimd': xsimd_dep.version()
-        }, section: 'Dependencies')
+}
+if xsimd_dep.found()
+    deps_summary += {'xsimd': xsimd_dep.version()}
+endif
+summary(deps_summary, section: 'Dependencies')
 
 summary({
     'CDFpp version': meson.project_version(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = 'mesonpy'
-requires = ['meson-python>=0.14.0', 'numpy', 'cmake']
+requires = ['meson-python>=0.14.0', 'numpy']
 
 [project]
 name = "pycdfpp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = 'mesonpy'
-requires = ['meson-python>=0.14.0', 'numpy']
+requires = ['meson-python>=0.14.0', 'numpy', 'cmake']
 
 [project]
 name = "pycdfpp"
@@ -45,9 +45,6 @@ enable="cpython-freethreading"
 [tool.cibuildwheel.windows]
 before-build = "python -m pip install delvewheel"
 repair-wheel-command = "python -m delvewheel repair -v --add-path C:/Windows/System32 -w {dest_dir} {wheel}"
-
-[tool.cibuildwheel.pyodide]
-before-build = "pip install cmake"
 
 
 [tool.bumpversion]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ enable="cpython-freethreading"
 before-build = "python -m pip install delvewheel"
 repair-wheel-command = "python -m delvewheel repair -v --add-path C:/Windows/System32 -w {dest_dir} {wheel}"
 
+[tool.cibuildwheel.pyodide]
+before-build = "pip install cmake"
+
 
 [tool.bumpversion]
 current_version = "0.9.3"

--- a/wacdfpp/cdfpp.d.ts
+++ b/wacdfpp/cdfpp.d.ts
@@ -1,0 +1,115 @@
+/** CDFpp WebAssembly module type declarations */
+
+type TypedArray =
+    | Int8Array
+    | Uint8Array
+    | Int16Array
+    | Uint16Array
+    | Int32Array
+    | Uint32Array
+    | BigInt64Array
+    | Float32Array
+    | Float64Array;
+
+export interface DataType {
+    readonly value: number;
+}
+
+export interface Majority {
+    readonly value: number;
+}
+
+export interface CompressionType {
+    readonly value: number;
+}
+
+/**
+ * A CDF variable returned as a plain JS object.
+ * `values` is a zero-copy typed array view into WASM memory — invalidated if the
+ * CdfFile is deleted or WASM memory grows.
+ * `copy_values` is an owned copy safe to keep indefinitely.
+ */
+export interface Variable {
+    readonly name: string;
+    readonly type: number;
+    readonly type_name: string;
+    readonly shape: number[];
+    readonly is_nrv: boolean;
+    readonly compression: string;
+    readonly values_loaded: boolean;
+    readonly attribute_names: string[];
+    readonly attributes: Record<string, string | TypedArray>;
+    readonly values: TypedArray | undefined;
+    readonly copy_values: TypedArray | undefined;
+}
+
+/** A CDF global attribute with one or more entries */
+export interface Attribute {
+    readonly name: string;
+    readonly entries: Array<string | TypedArray>;
+}
+
+/** A loaded CDF file (C++ backed — call delete() when done) */
+export interface CdfFile {
+    is_valid(): boolean;
+    variable_names(): string[];
+    attribute_names(): string[];
+    get_variable(name: string): Variable;
+    get_attribute(name: string): Attribute;
+    majority(): string;
+    compression(): string;
+
+    /** Serialize the CDF file to an owned Uint8Array */
+    save(): Uint8Array | undefined;
+
+    /** Free C++ memory — must be called when done */
+    delete(): void;
+}
+
+export interface CdfModule {
+    /** Load a CDF file from a Uint8Array buffer */
+    load(data: Uint8Array): CdfFile;
+
+    /** Get the string name of a CDF data type */
+    type_name(type: DataType): string;
+
+    /** Get the byte size of a CDF data type */
+    type_size(type: DataType): number;
+
+    DataType: {
+        CDF_NONE: DataType;
+        CDF_INT1: DataType;
+        CDF_INT2: DataType;
+        CDF_INT4: DataType;
+        CDF_INT8: DataType;
+        CDF_UINT1: DataType;
+        CDF_UINT2: DataType;
+        CDF_UINT4: DataType;
+        CDF_BYTE: DataType;
+        CDF_FLOAT: DataType;
+        CDF_REAL4: DataType;
+        CDF_DOUBLE: DataType;
+        CDF_REAL8: DataType;
+        CDF_EPOCH: DataType;
+        CDF_EPOCH16: DataType;
+        CDF_TIME_TT2000: DataType;
+        CDF_CHAR: DataType;
+        CDF_UCHAR: DataType;
+    };
+
+    Majority: {
+        row: Majority;
+        column: Majority;
+    };
+
+    CompressionType: {
+        none: CompressionType;
+        rle: CompressionType;
+        huffman: CompressionType;
+        adaptive_huffman: CompressionType;
+        gzip: CompressionType;
+    };
+}
+
+/** Initialize the CDFpp WASM module */
+export default function createCdfModule(): Promise<CdfModule>;

--- a/wacdfpp/meson.build
+++ b/wacdfpp/meson.build
@@ -1,23 +1,27 @@
 fs = import('fs')
 
-
-flags = ['-sWASM=2', '-sALLOW_MEMORY_GROWTH', '-sFETCH=1', '-sASYNCIFY']+['-sWASM=2', '-sEXPORT_ALL=1', '-sMODULARIZE', '-sEXPORTED_RUNTIME_METHODS=ccall', '-lembind', '-sFETCH=1', '--bind', '-sALLOW_MEMORY_GROWTH']
-
-lib_wacdfpp = library('wacdfpp', 'wacdfpp.cpp',
-                    dependencies:[cdfpp_dep],
-                    cpp_args : flags,
-                    install: false,
-                    link_args : flags,
-                    build_by_default: meson.get_compiler('cpp').get_id() == 'emscripten',
-                    extra_files : ['wasm.txt', 'wacdfpp.html']
-)
+flags = [
+    '-lembind',
+    '--bind',
+    '-sWASM=1',
+    '-sMODULARIZE=1',
+    '-sEXPORT_NAME=createCdfModule',
+    '-sALLOW_MEMORY_GROWTH=1',
+    '-sEXPORT_ES6=1',
+    '-sENVIRONMENT=web,worker,node',
+    '-sMAXIMUM_MEMORY=4GB',
+    '-fwasm-exceptions',
+]
 
 if meson.get_compiler('cpp').get_id() == 'emscripten'
-    js_wrapper = custom_target('js_wrapper',
-        input : lib_wacdfpp,
-        output : 'wacdfpp.js',
-        command : [ 'emcc', '-lembind', '-sFETCH=1', '-sWASM=2',  '--bind', '-sALLOW_MEMORY_GROWTH',  '-sASYNCIFY', '-o', '@OUTPUT@', '-Wl,--whole-archive','@INPUT@', '-Wl,--no-whole-archive'],
-        build_by_default: true
+    wasm_exe = executable('cdfpp',
+        'wacdfpp.cpp',
+        dependencies: [cdfpp_dep],
+        cpp_args: ['-fwasm-exceptions'],
+        link_args: flags + ['-O2'],
+        install: false,
+        build_by_default: true,
+        extra_files: ['wasm.txt', 'wacdfpp.html']
     )
 
     fs.copyfile('wacdfpp.html', 'wacdfpp.html')

--- a/wacdfpp/wacdfpp.cpp
+++ b/wacdfpp/wacdfpp.cpp
@@ -1,72 +1,299 @@
+/*------------------------------------------------------------------------------
+-- The MIT License (MIT)
+--
+-- Copyright © 2024, Laboratory of Plasma Physics- CNRS
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+-- of the Software, and to permit persons to whom the Software is furnished to do
+-- so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+-- INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+-- PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+-- HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+-- OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+-- SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-------------------------------------------------------------------------------*/
+/*-- Author : Alexis Jeandet
+-- Mail : alexis.jeandet@member.fsf.org
+----------------------------------------------------------------------------*/
 #include <cdfpp/cdf.hpp>
-#include <filesystem>
-#include <iostream>
+#include <cdfpp/cdf-io/saving/saving.hpp>
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include <cstdint>
 #include <string>
 #include <vector>
-#if __has_include(<emscripten.h>)
-#include <emscripten.h>
-#include <emscripten/bind.h>
-#include <emscripten/fetch.h>
-#else
-#define EMSCRIPTEN_KEEPALIVE
-#define EMSCRIPTEN_EXPORT(x) x
-#endif
 
+namespace em = emscripten;
 
-EMSCRIPTEN_KEEPALIVE
-emscripten::val count_variables(std::string url)
+namespace
 {
-    struct fetch_data
+
+em::val typed_array_view(const char* ptr, std::size_t byte_count, cdf::CDF_Types type)
+{
+    using enum cdf::CDF_Types;
+    switch (type)
     {
-        bool done = false;
-        std::vector<char> data;
-    };
-    emscripten_fetch_attr_t attr;
-    emscripten_fetch_attr_init(&attr);
-    strcpy(attr.requestMethod, "GET");
-    attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
-    attr.userData = new fetch_data;
-    attr.onsuccess = [](emscripten_fetch_t* fetch)
-    {
-        auto data = static_cast<fetch_data*>(fetch->userData);
-        data->data = std::vector<char>(fetch->data, fetch->data + fetch->numBytes);
-        data->done = true;
-        emscripten_fetch_close(fetch);
-    };
-    attr.onerror = [](emscripten_fetch_t* fetch)
-    {
-        auto data = static_cast<fetch_data*>(fetch->userData);
-        data->done = true;
-        emscripten_fetch_close(fetch);
-    };
-    emscripten_fetch(&attr, url.c_str());
-    while (!static_cast<fetch_data*>(attr.userData)->done)
-    {
-        emscripten_sleep(10);
+        case CDF_INT1:
+        case CDF_BYTE:
+            return em::val(em::typed_memory_view(byte_count, reinterpret_cast<const int8_t*>(ptr)));
+        case CDF_UINT1:
+            return em::val(
+                em::typed_memory_view(byte_count, reinterpret_cast<const uint8_t*>(ptr)));
+        case CDF_INT2:
+            return em::val(em::typed_memory_view(
+                byte_count / 2, reinterpret_cast<const int16_t*>(ptr)));
+        case CDF_UINT2:
+            return em::val(em::typed_memory_view(
+                byte_count / 2, reinterpret_cast<const uint16_t*>(ptr)));
+        case CDF_INT4:
+            return em::val(em::typed_memory_view(
+                byte_count / 4, reinterpret_cast<const int32_t*>(ptr)));
+        case CDF_UINT4:
+            return em::val(em::typed_memory_view(
+                byte_count / 4, reinterpret_cast<const uint32_t*>(ptr)));
+        case CDF_INT8:
+        case CDF_TIME_TT2000:
+            return em::val(em::typed_memory_view(
+                byte_count / 8, reinterpret_cast<const int64_t*>(ptr)));
+        case CDF_FLOAT:
+        case CDF_REAL4:
+            return em::val(
+                em::typed_memory_view(byte_count / 4, reinterpret_cast<const float*>(ptr)));
+        case CDF_DOUBLE:
+        case CDF_REAL8:
+        case CDF_EPOCH:
+            return em::val(em::typed_memory_view(
+                byte_count / 8, reinterpret_cast<const double*>(ptr)));
+        case CDF_EPOCH16:
+            return em::val(em::typed_memory_view(
+                byte_count / 8, reinterpret_cast<const double*>(ptr)));
+        case CDF_CHAR:
+        case CDF_UCHAR:
+            return em::val(
+                em::typed_memory_view(byte_count, reinterpret_cast<const uint8_t*>(ptr)));
+        case CDF_NONE:
+            return em::val::undefined();
     }
-    auto data = static_cast<fetch_data*>(attr.userData);
-    if (auto cdf_file = cdf::io::load(data->data); cdf_file)
+}
+
+em::val data_to_string_or_view(const cdf::data_t& data)
+{
+    auto ptr = data.bytes_ptr();
+    if (ptr == nullptr)
+        return em::val::undefined();
+    if (cdf::is_string(data.type()))
+        return em::val(std::string(ptr, data.bytes()));
+    return typed_array_view(ptr, data.bytes(), data.type());
+}
+
+em::val to_js_string_array(const auto& map)
+{
+    auto arr = em::val::array();
+    for (const auto& [name, _] : map)
+        arr.call<void>("push", name);
+    return arr;
+}
+
+} // namespace
+
+
+struct CdfFile
+{
+    std::optional<cdf::CDF> cdf;
+
+    bool is_valid() const { return cdf.has_value(); }
+
+    em::val variable_names() const
     {
-        std::cout << "Variables: " << std::size(cdf_file->variables) << "\n";
-        auto sz = std::size(cdf_file->variables);
-        delete data;
-        return emscripten::val(sz);
+        if (!cdf)
+            return em::val::array();
+        return to_js_string_array(cdf->variables);
     }
-    return emscripten::val(-1);
-}
 
+    em::val attribute_names() const
+    {
+        if (!cdf)
+            return em::val::array();
+        return to_js_string_array(cdf->attributes);
+    }
 
-EMSCRIPTEN_KEEPALIVE
-int my_cdf_test()
+    em::val get_variable(const std::string& name)
+    {
+        if (!cdf)
+            return em::val::undefined();
+        auto it = cdf->variables.find(name);
+        if (it == cdf->variables.end())
+            return em::val::undefined();
+
+        auto& var = it->second;
+        auto obj = em::val::object();
+        obj.set("name", var.name());
+        obj.set("type", static_cast<int>(var.type()));
+        obj.set("type_name", std::string(cdf::cdf_type_str(var.type())));
+        obj.set("is_nrv", var.is_nrv());
+        obj.set("compression", std::string(cdf::cdf_compression_type_str(var.compression_type())));
+        obj.set("values_loaded", var.values_loaded());
+
+        auto& shape = var.shape();
+        auto js_shape = em::val::array();
+        for (std::size_t i = 0; i < std::size(shape); ++i)
+            js_shape.call<void>("push", shape[i]);
+        obj.set("shape", js_shape);
+
+        obj.set("attribute_names", to_js_string_array(var.attributes));
+
+        // Lazily provide attribute getter as a plain object
+        auto attrs = em::val::object();
+        for (const auto& [aname, attr] : var.attributes)
+            attrs.set(aname, data_to_string_or_view(attr.value()));
+        obj.set("attributes", attrs);
+
+        // values: zero-copy typed array view into WASM memory
+        var.load_values();
+        auto ptr = var.bytes_ptr();
+        if (ptr != nullptr)
+        {
+            auto byte_count = var.bytes();
+            obj.set("values", typed_array_view(ptr, byte_count, var.type()));
+            // copy_values: owned copy safe to keep after CdfFile is freed
+            obj.set("copy_values", typed_array_view(ptr, byte_count, var.type())
+                                       .call<em::val>("slice"));
+        }
+        else
+        {
+            obj.set("values", em::val::undefined());
+            obj.set("copy_values", em::val::undefined());
+        }
+
+        return obj;
+    }
+
+    em::val get_attribute(const std::string& name) const
+    {
+        if (!cdf)
+            return em::val::undefined();
+        auto it = cdf->attributes.find(name);
+        if (it == cdf->attributes.end())
+            return em::val::undefined();
+
+        auto& attr = it->second;
+        auto obj = em::val::object();
+        obj.set("name", attr.name);
+        auto entries = em::val::array();
+        for (std::size_t i = 0; i < attr.size(); ++i)
+            entries.call<void>("push", data_to_string_or_view(attr[i]));
+        obj.set("entries", entries);
+        return obj;
+    }
+
+    std::string majority() const
+    {
+        if (!cdf)
+            return "unknown";
+        return cdf::cdf_majority_str(cdf->majority);
+    }
+
+    std::string compression() const
+    {
+        if (!cdf)
+            return "unknown";
+        return cdf::cdf_compression_type_str(cdf->compression);
+    }
+
+    em::val save_to_bytes() const
+    {
+        if (!cdf)
+            return em::val::undefined();
+        auto data = cdf::io::save(*cdf);
+        if (std::size(data) == 0)
+            return em::val::undefined();
+        // Create an owned Uint8Array copy (the local vector dies after return)
+        return em::val(em::typed_memory_view(std::size(data),
+            reinterpret_cast<const uint8_t*>(data.data())))
+            .call<em::val>("slice");
+    }
+};
+
+CdfFile load_cdf(em::val js_array)
 {
-    return 42;
+    CdfFile result;
+    try
+    {
+        auto length = js_array["length"].as<std::size_t>();
+        std::vector<char> buffer(length);
+        em::val dest(em::typed_memory_view(length, reinterpret_cast<uint8_t*>(buffer.data())));
+        dest.call<void>("set", js_array);
+        result.cdf = cdf::io::load(std::move(buffer), true, true);
+    }
+    catch (const std::exception& e)
+    {
+        em::val::global("console").call<void>("error",
+            std::string("CDFpp load error: ") + e.what());
+    }
+    catch (...)
+    {
+        em::val::global("console").call<void>("error",
+            std::string("CDFpp load error: unknown exception"));
+    }
+    return result;
 }
 
 
-#ifdef __EMSCRIPTEN__
-EMSCRIPTEN_BINDINGS(cdfppjs)
+EMSCRIPTEN_BINDINGS(cdfpp)
 {
-    emscripten::function("my_cdf_test", &my_cdf_test);
-    emscripten::function("count_variables", &count_variables);
+    em::enum_<cdf::CDF_Types>("DataType")
+        .value("CDF_NONE", cdf::CDF_Types::CDF_NONE)
+        .value("CDF_INT1", cdf::CDF_Types::CDF_INT1)
+        .value("CDF_INT2", cdf::CDF_Types::CDF_INT2)
+        .value("CDF_INT4", cdf::CDF_Types::CDF_INT4)
+        .value("CDF_INT8", cdf::CDF_Types::CDF_INT8)
+        .value("CDF_UINT1", cdf::CDF_Types::CDF_UINT1)
+        .value("CDF_UINT2", cdf::CDF_Types::CDF_UINT2)
+        .value("CDF_UINT4", cdf::CDF_Types::CDF_UINT4)
+        .value("CDF_BYTE", cdf::CDF_Types::CDF_BYTE)
+        .value("CDF_FLOAT", cdf::CDF_Types::CDF_FLOAT)
+        .value("CDF_REAL4", cdf::CDF_Types::CDF_REAL4)
+        .value("CDF_DOUBLE", cdf::CDF_Types::CDF_DOUBLE)
+        .value("CDF_REAL8", cdf::CDF_Types::CDF_REAL8)
+        .value("CDF_EPOCH", cdf::CDF_Types::CDF_EPOCH)
+        .value("CDF_EPOCH16", cdf::CDF_Types::CDF_EPOCH16)
+        .value("CDF_TIME_TT2000", cdf::CDF_Types::CDF_TIME_TT2000)
+        .value("CDF_CHAR", cdf::CDF_Types::CDF_CHAR)
+        .value("CDF_UCHAR", cdf::CDF_Types::CDF_UCHAR);
+
+    em::enum_<cdf::cdf_majority>("Majority")
+        .value("row", cdf::cdf_majority::row)
+        .value("column", cdf::cdf_majority::column);
+
+    em::enum_<cdf::cdf_compression_type>("CompressionType")
+        .value("none", cdf::cdf_compression_type::no_compression)
+        .value("rle", cdf::cdf_compression_type::rle_compression)
+        .value("huffman", cdf::cdf_compression_type::huff_compression)
+        .value("adaptive_huffman", cdf::cdf_compression_type::ahuff_compression)
+        .value("gzip", cdf::cdf_compression_type::gzip_compression);
+
+    em::class_<CdfFile>("CdfFile")
+        .function("is_valid", &CdfFile::is_valid)
+        .function("variable_names", &CdfFile::variable_names)
+        .function("attribute_names", &CdfFile::attribute_names)
+        .function("get_variable", &CdfFile::get_variable)
+        .function("get_attribute", &CdfFile::get_attribute)
+        .function("majority", &CdfFile::majority)
+        .function("compression", &CdfFile::compression)
+        .function("save", &CdfFile::save_to_bytes);
+
+    em::function("load", &load_cdf);
+    em::function("type_name",
+        +[](cdf::CDF_Types type) { return std::string(cdf::cdf_type_str(type)); });
+    em::function("type_size", &cdf::cdf_type_size);
 }
-#endif

--- a/wacdfpp/wacdfpp.html
+++ b/wacdfpp/wacdfpp.html
@@ -1,48 +1,138 @@
 <!doctype html>
 <html>
+<head>
+    <meta charset="utf-8">
+    <title>CDFpp WASM Demo</title>
+    <style>
+        body { font-family: monospace; max-width: 900px; margin: 2em auto; }
+        #output { white-space: pre-wrap; background: #f4f4f4; padding: 1em; margin-top: 1em; max-height: 600px; overflow-y: auto; }
+        input[type="file"] { margin: 0.5em 0; }
+        button { margin-left: 0.5em; }
+    </style>
+</head>
 <body>
-<canvas id="canvas" width="400" height="400"></canvas>
-<div id="container">
-  <p>
-    <input type="text" id="URL" name="URL" />
-    <input id="myButton" type=button value="Read CDF">
-    <output name="result" id="count"/>
-  </p>
+<h2>CDFpp WASM Demo</h2>
+
+<div>
+    <label>Load a CDF file:</label><br>
+    <input type="file" id="fileInput" accept=".cdf">
+    <button id="loadBtn" disabled>Inspect</button>
 </div>
-<script>
 
-  console.log("loading wasm");
+<div>
+    <label>Or fetch from URL:</label><br>
+    <input type="text" id="urlInput" size="60" placeholder="https://example.com/data.cdf">
+    <button id="fetchBtn" disabled>Fetch &amp; Inspect</button>
+</div>
 
-  var Module = {
-    canvas: (function() {
-      var canvas = document.getElementById('canvas');
-      return canvas;
-    })(),
+<div id="output">Initializing WASM module...</div>
 
-    onRuntimeInitialized: function() {
-      console.log("wasm loaded");
-      console.log("wasm initialized");
+<script type="module">
+    import createCdfModule from './cdfpp.js';
+
+    const output = document.getElementById('output');
+    const fileInput = document.getElementById('fileInput');
+    const loadBtn = document.getElementById('loadBtn');
+    const fetchBtn = document.getElementById('fetchBtn');
+    const urlInput = document.getElementById('urlInput');
+
+    let Module;
+
+    function log(text) { output.textContent += text + '\n'; }
+    function clear() { output.textContent = ''; }
+
+    function inspectCdf(cdf) {
+        if (!cdf.is_valid()) {
+            log('ERROR: Failed to parse CDF file');
+            cdf.delete();
+            return;
+        }
+
+        log(`Majority: ${cdf.majority()}`);
+        log(`Compression: ${cdf.compression()}`);
+
+        const attrNames = cdf.attribute_names();
+        log(`\nGlobal Attributes (${attrNames.length}):`);
+        for (const name of attrNames) {
+            const attr = cdf.get_attribute(name);
+            const entries = attr.entries.map(v =>
+                typeof v === 'string' ? `"${v.trim()}"` : v);
+            log(`  ${name}: ${entries.join(', ')}`);
+        }
+
+        const varNames = cdf.variable_names();
+        log(`\nVariables (${varNames.length}):`);
+        for (const name of varNames) {
+            const v = cdf.get_variable(name);
+            log(`  ${name}: shape=[${v.shape}] type=${v.type_name} nrv=${v.is_nrv}`);
+
+            for (const an of v.attribute_names) {
+                const av = v.attributes[an];
+                const display = typeof av === 'string' ? `"${av.trim()}"` : av;
+                log(`    ${an}: ${display}`);
+            }
+
+            const values = v.values;
+            if (values !== undefined && values.length > 0) {
+                const preview = Array.from(values.slice(0, Math.min(5, values.length)));
+                const suffix = values.length > 5 ? ` ... (${values.length} total)` : '';
+                log(`    values: [${preview}${suffix}]`);
+            }
+        }
+
+        const savedBytes = cdf.save();
+        if (savedBytes !== undefined) {
+            log(`\nRound-trip save: ${savedBytes.length} bytes`);
+        }
+
+        cdf.delete();
     }
-  };
-</script>
-<script src="wacdfpp.js"></script>
 
-<script>
-  function callback() {
-    const URL = document.getElementById("URL").value;
+    async function init() {
+        Module = await createCdfModule();
+        output.textContent = 'Ready. Load a CDF file or fetch from URL.\n';
+        loadBtn.disabled = false;
+        fetchBtn.disabled = false;
+    }
 
-    // Disable the button while the operation is in progress
-    document.getElementById("myButton").disabled = true;
-
-    // Fetch the data and process it asynchronously
-    Module.count_variables(URL).then(function(count) {
-      // Update the count and enable the button when processing is done
-      document.getElementById("count").innerHTML = count;
-      document.getElementById("myButton").disabled = false;
+    loadBtn.addEventListener('click', () => {
+        const file = fileInput.files[0];
+        if (!file) return;
+        clear();
+        log(`Loading: ${file.name} (${file.size} bytes)\n`);
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            const data = new Uint8Array(e.target.result);
+            const t0 = performance.now();
+            const cdf = Module.load(data);
+            const dt = (performance.now() - t0).toFixed(1);
+            log(`Parsed in ${dt} ms\n`);
+            inspectCdf(cdf);
+        };
+        reader.readAsArrayBuffer(file);
     });
-  }
 
-  myButton.addEventListener('click', callback);
+    fetchBtn.addEventListener('click', async () => {
+        const url = urlInput.value.trim();
+        if (!url) return;
+        clear();
+        log(`Fetching: ${url}\n`);
+        try {
+            const resp = await fetch(url);
+            const buf = await resp.arrayBuffer();
+            const data = new Uint8Array(buf);
+            log(`Downloaded ${data.length} bytes\n`);
+            const t0 = performance.now();
+            const cdf = Module.load(data);
+            const dt = (performance.now() - t0).toFixed(1);
+            log(`Parsed in ${dt} ms\n`);
+            inspectCdf(cdf);
+        } catch (err) {
+            log(`Fetch error: ${err.message}`);
+        }
+    });
+
+    init();
 </script>
 </body>
 </html>

--- a/wacdfpp/wacdfpp.html
+++ b/wacdfpp/wacdfpp.html
@@ -1,31 +1,269 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>CDFpp WASM Demo</title>
     <style>
-        body { font-family: monospace; max-width: 900px; margin: 2em auto; }
-        #output { white-space: pre-wrap; background: #f4f4f4; padding: 1em; margin-top: 1em; max-height: 600px; overflow-y: auto; }
-        input[type="file"] { margin: 0.5em 0; }
-        button { margin-left: 0.5em; }
+        :root {
+            --bg: #0f1117;
+            --surface: #1a1d27;
+            --surface2: #242836;
+            --border: #2e3345;
+            --text: #e2e4eb;
+            --text-dim: #8b8fa3;
+            --accent: #6c8aff;
+            --accent-dim: rgba(108, 138, 255, 0.12);
+            --green: #4ade80;
+            --yellow: #fbbf24;
+            --red: #f87171;
+            --mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'JetBrains Mono', Consolas, monospace;
+            --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+            --radius: 8px;
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: var(--sans);
+            background: var(--bg);
+            color: var(--text);
+            line-height: 1.6;
+            min-height: 100vh;
+        }
+
+        .container {
+            max-width: 960px;
+            margin: 0 auto;
+            padding: 2rem 1.5rem;
+        }
+
+        header {
+            display: flex;
+            align-items: baseline;
+            gap: 0.75rem;
+            margin-bottom: 2rem;
+        }
+
+        header h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            letter-spacing: -0.02em;
+        }
+
+        header .badge {
+            font-family: var(--mono);
+            font-size: 0.7rem;
+            padding: 0.2em 0.6em;
+            background: var(--accent-dim);
+            color: var(--accent);
+            border-radius: 4px;
+            font-weight: 500;
+        }
+
+        .input-section {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+        }
+
+        @media (max-width: 640px) {
+            .input-section { grid-template-columns: 1fr; }
+        }
+
+        .card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            padding: 1.25rem;
+        }
+
+        .card label {
+            display: block;
+            font-size: 0.8rem;
+            font-weight: 500;
+            color: var(--text-dim);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.75rem;
+        }
+
+        .card .row {
+            display: flex;
+            gap: 0.5rem;
+            align-items: center;
+        }
+
+        input[type="file"] {
+            font-family: var(--sans);
+            font-size: 0.85rem;
+            color: var(--text);
+            min-width: 0;
+            flex: 1;
+        }
+
+        input[type="file"]::file-selector-button {
+            font-family: var(--sans);
+            font-size: 0.8rem;
+            font-weight: 500;
+            padding: 0.4em 0.8em;
+            background: var(--surface2);
+            color: var(--text);
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+
+        input[type="file"]::file-selector-button:hover {
+            background: var(--border);
+        }
+
+        input[type="text"] {
+            font-family: var(--mono);
+            font-size: 0.85rem;
+            flex: 1;
+            min-width: 0;
+            padding: 0.45em 0.7em;
+            background: var(--bg);
+            color: var(--text);
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            outline: none;
+            transition: border-color 0.15s;
+        }
+
+        input[type="text"]:focus {
+            border-color: var(--accent);
+        }
+
+        input[type="text"]::placeholder {
+            color: var(--text-dim);
+            opacity: 0.6;
+        }
+
+        button {
+            font-family: var(--sans);
+            font-size: 0.8rem;
+            font-weight: 500;
+            padding: 0.45em 1em;
+            background: var(--accent);
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: opacity 0.15s;
+        }
+
+        button:hover:not(:disabled) { opacity: 0.85; }
+        button:disabled { opacity: 0.35; cursor: not-allowed; }
+
+        #status {
+            font-family: var(--mono);
+            font-size: 0.75rem;
+            color: var(--text-dim);
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5em;
+        }
+
+        #status .dot {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: var(--text-dim);
+            display: inline-block;
+        }
+
+        #status.ready .dot { background: var(--green); }
+        #status.loading .dot { background: var(--yellow); animation: pulse 1s infinite; }
+        #status.error .dot { background: var(--red); }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.3; }
+        }
+
+        #output-container {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            overflow: hidden;
+        }
+
+        #output-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.6rem 1rem;
+            background: var(--surface2);
+            border-bottom: 1px solid var(--border);
+            font-size: 0.75rem;
+            color: var(--text-dim);
+        }
+
+        #output-header span { font-family: var(--mono); }
+
+        #output {
+            font-family: var(--mono);
+            font-size: 0.8rem;
+            line-height: 1.7;
+            padding: 1rem 1.25rem;
+            max-height: 65vh;
+            overflow-y: auto;
+            white-space: pre-wrap;
+            word-break: break-all;
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+        }
+
+        .log-section { color: var(--accent); font-weight: 600; }
+        .log-key { color: var(--green); }
+        .log-dim { color: var(--text-dim); }
+        .log-val { color: var(--yellow); }
+        .log-err { color: var(--red); }
     </style>
 </head>
 <body>
-<h2>CDFpp WASM Demo</h2>
+<div class="container">
+    <header>
+        <h1>CDFpp WASM Demo</h1>
+        <span class="badge">WebAssembly</span>
+    </header>
 
-<div>
-    <label>Load a CDF file:</label><br>
-    <input type="file" id="fileInput" accept=".cdf">
-    <button id="loadBtn" disabled>Inspect</button>
+    <div class="input-section">
+        <div class="card">
+            <label>Load local file</label>
+            <div class="row">
+                <input type="file" id="fileInput" accept=".cdf">
+                <button id="loadBtn" disabled>Inspect</button>
+            </div>
+        </div>
+        <div class="card">
+            <label>Fetch from URL</label>
+            <div class="row">
+                <input type="text" id="urlInput" placeholder="https://example.com/data.cdf">
+                <button id="fetchBtn" disabled>Fetch</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="status" class="loading">
+        <span class="dot"></span>
+        <span id="statusText">Initializing WASM module...</span>
+    </div>
+
+    <div id="output-container">
+        <div id="output-header">
+            <span id="fileName">No file loaded</span>
+            <span id="parseTime"></span>
+        </div>
+        <div id="output"></div>
+    </div>
 </div>
-
-<div>
-    <label>Or fetch from URL:</label><br>
-    <input type="text" id="urlInput" size="60" placeholder="https://example.com/data.cdf">
-    <button id="fetchBtn" disabled>Fetch &amp; Inspect</button>
-</div>
-
-<div id="output">Initializing WASM module...</div>
 
 <script type="module">
     import createCdfModule from './cdfpp.js';
@@ -35,79 +273,106 @@
     const loadBtn = document.getElementById('loadBtn');
     const fetchBtn = document.getElementById('fetchBtn');
     const urlInput = document.getElementById('urlInput');
+    const statusEl = document.getElementById('status');
+    const statusText = document.getElementById('statusText');
+    const fileName = document.getElementById('fileName');
+    const parseTime = document.getElementById('parseTime');
 
     let Module;
 
-    function log(text) { output.textContent += text + '\n'; }
-    function clear() { output.textContent = ''; }
+    function setStatus(cls, text) {
+        statusEl.className = cls;
+        statusText.textContent = text;
+    }
 
-    function inspectCdf(cdf) {
+    function span(cls, text) { return `<span class="${cls}">${text}</span>`; }
+
+    function log(html) { output.innerHTML += html + '\n'; }
+    function clear() { output.innerHTML = ''; }
+
+    function esc(s) {
+        return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    function inspectCdf(cdf, name, dt) {
         if (!cdf.is_valid()) {
-            log('ERROR: Failed to parse CDF file');
+            log(span('log-err', 'ERROR: Failed to parse CDF file'));
             cdf.delete();
             return;
         }
 
-        log(`Majority: ${cdf.majority()}`);
-        log(`Compression: ${cdf.compression()}`);
+        fileName.textContent = name;
+        parseTime.textContent = `parsed in ${dt} ms`;
+
+        log(span('log-section', '[ File Info ]'));
+        log(`  Majority     ${span('log-val', cdf.majority())}`);
+        log(`  Compression  ${span('log-val', cdf.compression())}`);
 
         const attrNames = cdf.attribute_names();
-        log(`\nGlobal Attributes (${attrNames.length}):`);
+        log('');
+        log(span('log-section', `[ Global Attributes ] `) + span('log-dim', `(${attrNames.length})`));
         for (const name of attrNames) {
             const attr = cdf.get_attribute(name);
             const entries = attr.entries.map(v =>
-                typeof v === 'string' ? `"${v.trim()}"` : v);
-            log(`  ${name}: ${entries.join(', ')}`);
+                typeof v === 'string' ? `"${esc(v.trim())}"` : v);
+            log(`  ${span('log-key', esc(name))}  ${span('log-dim', entries.join(', '))}`);
         }
 
         const varNames = cdf.variable_names();
-        log(`\nVariables (${varNames.length}):`);
+        log('');
+        log(span('log-section', `[ Variables ] `) + span('log-dim', `(${varNames.length})`));
         for (const name of varNames) {
             const v = cdf.get_variable(name);
-            log(`  ${name}: shape=[${v.shape}] type=${v.type_name} nrv=${v.is_nrv}`);
+            log(`  ${span('log-key', esc(name))}  ${span('log-dim', `[${v.shape}]`)} ${span('log-val', v.type_name)}${v.is_nrv ? span('log-dim', ' nrv') : ''}`);
 
             for (const an of v.attribute_names) {
                 const av = v.attributes[an];
-                const display = typeof av === 'string' ? `"${av.trim()}"` : av;
-                log(`    ${an}: ${display}`);
+                const display = typeof av === 'string' ? `"${esc(av.trim())}"` : av;
+                log(`    ${span('log-dim', esc(an) + ':')} ${display}`);
             }
 
             const values = v.values;
             if (values !== undefined && values.length > 0) {
                 const preview = Array.from(values.slice(0, Math.min(5, values.length)));
-                const suffix = values.length > 5 ? ` ... (${values.length} total)` : '';
-                log(`    values: [${preview}${suffix}]`);
+                const suffix = values.length > 5 ? span('log-dim', ` ... (${values.length} total)`) : '';
+                log(`    ${span('log-dim', 'values:')} [${preview}${suffix}]`);
             }
         }
 
         const savedBytes = cdf.save();
         if (savedBytes !== undefined) {
-            log(`\nRound-trip save: ${savedBytes.length} bytes`);
+            log('');
+            log(span('log-section', '[ Round-trip ]'));
+            log(`  Save size  ${span('log-val', savedBytes.length.toLocaleString() + ' bytes')}`);
         }
 
         cdf.delete();
     }
 
     async function init() {
-        Module = await createCdfModule();
-        output.textContent = 'Ready. Load a CDF file or fetch from URL.\n';
-        loadBtn.disabled = false;
-        fetchBtn.disabled = false;
+        try {
+            Module = await createCdfModule();
+            setStatus('ready', 'Ready');
+            loadBtn.disabled = false;
+            fetchBtn.disabled = false;
+        } catch (err) {
+            setStatus('error', `Init failed: ${err.message}`);
+        }
     }
 
     loadBtn.addEventListener('click', () => {
         const file = fileInput.files[0];
         if (!file) return;
         clear();
-        log(`Loading: ${file.name} (${file.size} bytes)\n`);
+        setStatus('loading', `Loading ${file.name}...`);
         const reader = new FileReader();
         reader.onload = (e) => {
             const data = new Uint8Array(e.target.result);
             const t0 = performance.now();
             const cdf = Module.load(data);
             const dt = (performance.now() - t0).toFixed(1);
-            log(`Parsed in ${dt} ms\n`);
-            inspectCdf(cdf);
+            setStatus('ready', `Loaded ${file.name} (${data.length.toLocaleString()} bytes)`);
+            inspectCdf(cdf, file.name, dt);
         };
         reader.readAsArrayBuffer(file);
     });
@@ -116,19 +381,21 @@
         const url = urlInput.value.trim();
         if (!url) return;
         clear();
-        log(`Fetching: ${url}\n`);
+        setStatus('loading', 'Fetching...');
         try {
             const resp = await fetch(url);
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
             const buf = await resp.arrayBuffer();
             const data = new Uint8Array(buf);
-            log(`Downloaded ${data.length} bytes\n`);
+            const name = url.split('/').pop() || 'remote.cdf';
             const t0 = performance.now();
             const cdf = Module.load(data);
             const dt = (performance.now() - t0).toFixed(1);
-            log(`Parsed in ${dt} ms\n`);
-            inspectCdf(cdf);
+            setStatus('ready', `Fetched ${name} (${data.length.toLocaleString()} bytes)`);
+            inspectCdf(cdf, name, dt);
         } catch (err) {
-            log(`Fetch error: ${err.message}`);
+            setStatus('error', `Fetch error: ${err.message}`);
+            log(span('log-err', `Error: ${esc(err.message)}`));
         }
     });
 

--- a/wacdfpp/wasm.txt
+++ b/wacdfpp/wasm.txt
@@ -5,9 +5,9 @@ ar = 'emar'
 exe_wrapper = 'node'
 
 [built-in options]
-c_args = []
-c_link_args = ['-sEXPORT_ALL=1', '-sWASM=2', '-sMODULARIZE', '-sEXPORTED_RUNTIME_METHODS=ccall']
-cpp_args = []
+c_args = ['-fwasm-exceptions']
+c_link_args = []
+cpp_args = ['-fwasm-exceptions']
 cpp_link_args = []
 
 


### PR DESCRIPTION
## Summary
- Rewrites the WASM/Emscripten wrapper (`wacdfpp/`) with full CDF read/write support, lazy loading, and zero-copy TypedArray access
- Redesigns the HTML demo with a dark-themed responsive UI, syntax-colored output, and status indicators
- Adds a GitHub Pages CI workflow (`gh-pages.yml`) that builds with emsdk and deploys the demo on pushes to main

## Notes
- GitHub Pages source must be set to "GitHub Actions" in repo settings (Settings > Pages > Source)
- Once enabled, the demo will be available at https://sciqlop.github.io/CDFpp/

## Test plan
- [ ] Build WASM locally with `meson setup build_wasm --cross-file wacdfpp/wasm.txt -Ddisable_python_wrapper=true -Dwith_experimental_wasm=true && ninja -C build_wasm`
- [ ] Open `build_wasm/wacdfpp/wacdfpp.html` via local HTTP server and load a CDF file
- [ ] Verify URL fetch works with a remote CDF file
- [ ] Verify GH Pages workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)