### PR TITLE
Enable WASM wheel upload to PyPI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,7 +72,7 @@ jobs:
           key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.CIBW_ARCHS }}  # Make cache specific to OS/ARCH
           max-size: "5G"
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
+        uses: pypa/cibuildwheel@v4.0.0rc1
       - uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.CIBW_ARCHS }}
@@ -163,8 +163,6 @@ jobs:
           pattern: cibw-*
           path: dist
           merge-multiple: true
-      - name: Remove wasm32 wheels (until PyPI PEP 783 is implemented)
-        run: find dist -name "*wasm32.whl" -delete
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -186,8 +184,6 @@ jobs:
           pattern: cibw-*
           path: dist
           merge-multiple: true
-      - name: Remove wasm32 wheels (until PyPI PEP 783 is implemented)
-        run: find dist -name "*wasm32.whl" -delete
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ setup = ['-Doptimization=3', '-Dcpp_std=c++20', '--force-fallback-for=libdeflate
 [tool.cibuildwheel]
 archs = ["auto"]
 build-frontend = "default"
-enable="cpython-freethreading"
 
 [tool.cibuildwheel.windows]
 before-build = "python -m pip install delvewheel"


### PR DESCRIPTION
## Summary

- **Upgrade cibuildwheel** from `v3.4.1` to `v4.0.0rc1`, which adds PEP 783 `pyemscripten` platform tag support for Pyodide/WASM wheels
- **Remove WASM deletion steps** from both `upload_pypi` and `upload_test_pypi` jobs — PyPI now supports uploading `pyemscripten` wheels per PEP 783
- **Remove deprecated `cpython-freethreading` enable option** (removed in cibuildwheel v4; 3.14+ free-threading builds are automatic)

The WASM/Pyodide wheel build (`CIBW_PLATFORM=pyodide`, `CIBW_ARCHS=wasm32`) was already in the matrix — it was just being thrown away before upload.