### PR TITLE
Expose UTC time conversion in the WASM build

### DIFF
--- a/tests/wasm_time_conversion/test.mjs
+++ b/tests/wasm_time_conversion/test.mjs
@@ -1,0 +1,103 @@
+// Node test for CdfFile.time_values_as_ns_since_1970 (WASM build).
+//
+// Oracle values come from pycdfpp's to_datetime64() on the same resource files,
+// which uses the exact same cdf::to_ns_from_1970() leap-second-correct path.
+// Run after building the WASM module:
+//   node test.mjs <path-to-cdfpp.js> <path-to-tests/resources>
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+
+const [, , modulePath, resourcesDir] = process.argv;
+if (!modulePath || !resourcesDir)
+{
+    console.error("usage: node test.mjs <cdfpp.js> <resources_dir>");
+    process.exit(2);
+}
+
+const { default: createCdfModule } = await import(modulePath);
+const Module = await createCdfModule();
+
+let failures = 0;
+function check(name, actual, expected)
+{
+    const ok = actual === expected;
+    if (!ok)
+    {
+        failures += 1;
+        console.error(`FAIL ${name}: got ${actual}, expected ${expected}`);
+    }
+    else
+    {
+        console.log(`ok   ${name}`);
+    }
+}
+
+function load(file)
+{
+    const bytes = new Uint8Array(readFileSync(join(resourcesDir, file)));
+    const cdf = Module.load(bytes);
+    if (!cdf.is_valid())
+        throw new Error(`failed to load ${file}`);
+    return cdf;
+}
+
+// a_cdf.cdf: all three time types, 101 points each (exercises the threaded/bulk path).
+//
+// Note on tt2000[0]: its raw J2000 value decodes to 1969-12-31T23:59:59, i.e. before
+// the NASA leap-second table's first entry (1972-01-01). In that undefined extrapolation
+// zone CDFpp's scalar conversion (this WASM build, xsimd gated off non-x86) and its SIMD
+// conversion (pycdfpp on x86) disagree by 9 s. We therefore don't pin element 0 here;
+// leap-second correctness is pinned by testutf8.cdf below (spans the 2015 leap second).
+{
+    const cdf = load("a_cdf.cdf");
+    const cases = {
+        epoch: { n: 101, first: 0n, last: 1555200000000000000n },
+        epoch16: { n: 101, first: 0n, last: 1555200000000000000n },
+        tt2000: { n: 101, last: 1555200000000000000n },
+    };
+    for (const [varname, exp] of Object.entries(cases))
+    {
+        const ns = cdf.time_values_as_ns_since_1970(varname);
+        check(`a_cdf.cdf/${varname} length`, ns.length, exp.n);
+        if (exp.first !== undefined)
+            check(`a_cdf.cdf/${varname} first`, ns[0], exp.first);
+        check(`a_cdf.cdf/${varname} last`, ns[ns.length - 1], exp.last);
+    }
+    cdf.delete();
+}
+
+// testutf8.cdf: small arrays (scalar path, n<8); tt2000 spans the 2015 leap second.
+{
+    const cdf = load("testutf8.cdf");
+    const expected = {
+        ep: [920610367100000000n, 883710245666000000n],
+        ep16: [1101743723030411520n, 1104339384031411584n, 1135875384031444608n],
+        tt2000: [
+            1435708798123456789n, 1435708799123456789n, 1435708800123456789n,
+            1435708800123456789n, 1435708801123456789n, 1435708802123456789n,
+        ],
+    };
+    for (const [varname, exp] of Object.entries(expected))
+    {
+        const ns = cdf.time_values_as_ns_since_1970(varname);
+        check(`testutf8.cdf/${varname} length`, ns.length, exp.length);
+        for (let i = 0; i < exp.length; i++)
+            check(`testutf8.cdf/${varname}[${i}]`, ns[i], exp[i]);
+    }
+
+    // Non-time variable and missing variable both return undefined.
+    check("non-time var -> undefined",
+        cdf.time_values_as_ns_since_1970("Latitude") === undefined, true);
+    check("missing var -> undefined",
+        cdf.time_values_as_ns_since_1970("does_not_exist") === undefined, true);
+    cdf.delete();
+}
+
+if (failures > 0)
+{
+    console.error(`\n${failures} check(s) failed`);
+    process.exit(1);
+}
+console.log("\nall checks passed");

--- a/wacdfpp/cdfpp.d.ts
+++ b/wacdfpp/cdfpp.d.ts
@@ -55,6 +55,14 @@ export interface CdfFile {
     variable_names(): string[];
     attribute_names(): string[];
     get_variable(name: string): Variable;
+
+    /**
+     * UTC nanoseconds since 1970 (leap-second corrected) for a time variable
+     * (CDF_TIME_TT2000 / CDF_EPOCH / CDF_EPOCH16). The JS analog of
+     * datetime64[ns]. Returns undefined for non-time variables.
+     */
+    time_values_as_ns_since_1970(name: string): BigInt64Array | undefined;
+
     get_attribute(name: string): Attribute;
     majority(): string;
     compression(): string;

--- a/wacdfpp/meson.build
+++ b/wacdfpp/meson.build
@@ -25,4 +25,17 @@ if meson.get_compiler('cpp').get_id() == 'emscripten'
     )
 
     fs.copyfile('wacdfpp.html', 'wacdfpp.html')
+
+    node = find_program('node', required: false)
+    if node.found()
+        test('wasm_time_conversion', node,
+            args: [
+                files('../tests/wasm_time_conversion/test.mjs'),
+                meson.current_build_dir() / 'cdfpp.js',
+                meson.project_source_root() / 'tests' / 'resources',
+            ],
+            depends: wasm_exe,
+            timeout: 120,
+        )
+    endif
 endif

--- a/wacdfpp/wacdfpp.cpp
+++ b/wacdfpp/wacdfpp.cpp
@@ -25,6 +25,7 @@
 ----------------------------------------------------------------------------*/
 #include <cdfpp/cdf.hpp>
 #include <cdfpp/cdf-io/saving/saving.hpp>
+#include <cdfpp/chrono/cdf-chrono.hpp>
 
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
@@ -178,6 +179,60 @@ struct CdfFile
         return obj;
     }
 
+    // UTC nanoseconds since 1970 for a time variable (CDF_TIME_TT2000 / CDF_EPOCH /
+    // CDF_EPOCH16), leap-second corrected. Returns undefined for non-time variables.
+    // This is the JS analog of pycdfpp's datetime64[ns].
+    em::val time_values_as_ns_since_1970(const std::string& name)
+    {
+        using enum cdf::CDF_Types;
+        if (!cdf)
+            return em::val::undefined();
+        auto it = cdf->variables.find(name);
+        if (it == cdf->variables.end())
+            return em::val::undefined();
+
+        auto& var = it->second;
+        const auto type = var.type();
+        if (type != CDF_TIME_TT2000 && type != CDF_EPOCH && type != CDF_EPOCH16)
+            return em::val::undefined();
+
+        var.load_values();
+        const auto* ptr = var.bytes_ptr();
+        if (ptr == nullptr)
+            return em::val::undefined();
+
+        const std::size_t n = var.bytes() / cdf::cdf_type_size(type);
+        if (n == 0)
+            return em::val::undefined();
+
+        std::vector<int64_t> out(n);
+        switch (type)
+        {
+            case CDF_TIME_TT2000:
+                cdf::to_ns_from_1970(
+                    std::span<const cdf::tt2000_t>(
+                        reinterpret_cast<const cdf::tt2000_t*>(ptr), n),
+                    out.data());
+                break;
+            case CDF_EPOCH:
+                cdf::to_ns_from_1970(
+                    std::span<const cdf::epoch>(reinterpret_cast<const cdf::epoch*>(ptr), n),
+                    out.data());
+                break;
+            case CDF_EPOCH16:
+                cdf::to_ns_from_1970(
+                    std::span<const cdf::epoch16>(
+                        reinterpret_cast<const cdf::epoch16*>(ptr), n),
+                    out.data());
+                break;
+            default:
+                return em::val::undefined();
+        }
+
+        // owned BigInt64Array copy (out dies after return)
+        return em::val(em::typed_memory_view(n, out.data())).call<em::val>("slice");
+    }
+
     em::val get_attribute(const std::string& name) const
     {
         if (!cdf)
@@ -287,6 +342,7 @@ EMSCRIPTEN_BINDINGS(cdfpp)
         .function("variable_names", &CdfFile::variable_names)
         .function("attribute_names", &CdfFile::attribute_names)
         .function("get_variable", &CdfFile::get_variable)
+        .function("time_values_as_ns_since_1970", &CdfFile::time_values_as_ns_since_1970)
         .function("get_attribute", &CdfFile::get_attribute)
         .function("majority", &CdfFile::majority)
         .function("compression", &CdfFile::compression)


### PR DESCRIPTION
## Motivation

The WASM build returns `CDF_TIME_TT2000` variables as raw `BigInt64Array` of TT2000 nanoseconds (J2000 epoch, no leap-second correction). Consumers (e.g. the speasy-proxy web viewers decoding `format=cdf` in the browser) need **UTC nanoseconds since 1970** — the same `datetime64[ns]` that `pycdfpp` already produces. The leap-second table is authoritative inside CDFpp and must not be re-implemented in JS; this PR exposes the conversion that already exists.

## Changes

- **`wacdfpp/wacdfpp.cpp`** — new `CdfFile.time_values_as_ns_since_1970(name)` method, reusing `cdf::to_ns_from_1970` for `CDF_TIME_TT2000` / `CDF_EPOCH` / `CDF_EPOCH16`. Returns an owned `BigInt64Array`; `undefined` for non-time/missing variables.
- **`wacdfpp/cdfpp.d.ts`** — matching TypeScript declaration.
- **`tests/wasm_time_conversion/test.mjs`** — Node test using `pycdfpp.to_datetime64()` as the oracle. Covers all three time types, bulk + scalar paths, the 2015 leap second (`testutf8.cdf`), and undefined returns.
- **`wacdfpp/meson.build`** — wires the test into `ninja test` for the WASM build, guarded on `node` being found (native builds unaffected).

## Verification

Built with emsdk 4.0.9; `meson test -C build_wasm wasm_time_conversion` passes (24 checks).

## Note: pre-existing scalar/SIMD divergence

The test surfaced (but does not fix) a divergence in CDFpp's chrono: for TT2000 timestamps **before 1972** (the leap-second table's first entry — undefined extrapolation), the scalar path and the SIMD `vectorized_to_ns_from_1970` disagree by ~9 s. This affects `a_cdf.cdf` tt2000[0] (decodes to 1969-12-31). Real ISTP data is post-1972 so it is harmless in practice; the test therefore pins leap-second correctness via the 2015 leap second in `testutf8.cdf` rather than the undefined pre-1972 value. A future fix would align the vectorized underflow boundary with the scalar path in `include/cdfpp/vectorized/cdf-chrono.hpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)