### PR TITLE
Fix detached-ArrayBuffer crash on attribute values in the WASM wrapper

### DIFF
--- a/tests/wasm_attr_detach/test.mjs
+++ b/tests/wasm_attr_detach/test.mjs
@@ -1,0 +1,107 @@
+// Node test: attribute values must survive WASM heap growth (WASM build).
+//
+// Regression test for the "detached ArrayBuffer" bug: numeric attribute values
+// were handed to JS as zero-copy views into the WASM heap. Loading a variable's
+// data (decompression) — or any later allocation — grows the heap and detaches
+// every outstanding view, so reading such an attribute later threw
+// "Cannot perform %TypedArray%.prototype.join on a detached ArrayBuffer".
+// The fix makes attribute values owned copies. This test forces heap growth and
+// checks a captured numeric attribute is still readable.
+//
+//   node test.mjs <path-to-cdfpp.js> <path-to-tests/resources>
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+
+const [, , modulePath, resourcesDir] = process.argv;
+if (!modulePath || !resourcesDir)
+{
+    console.error("usage: node test.mjs <cdfpp.js> <resources_dir>");
+    process.exit(2);
+}
+
+const { default: createCdfModule } = await import(modulePath);
+const Module = await createCdfModule();
+
+let failures = 0;
+function check(name, ok)
+{
+    if (ok)
+        console.log(`ok   ${name}`);
+    else
+    {
+        failures += 1;
+        console.error(`FAIL ${name}`);
+    }
+}
+
+function load(file)
+{
+    const bytes = new Uint8Array(readFileSync(join(resourcesDir, file)));
+    const cdf = Module.load(bytes);
+    if (!cdf.is_valid())
+        throw new Error(`failed to load ${file}`);
+    return cdf;
+}
+
+// Grow the WASM heap by allocating a large buffer inside the module. Module.load
+// copies its input into a WASM-side std::vector, so a big (invalid) input forces
+// the heap to grow well past the initial size, detaching any stale views.
+function forceHeapGrowth()
+{
+    const big = Module.load(new Uint8Array(96 * 1024 * 1024));
+    big.delete();
+}
+
+// Find the first variable carrying a numeric (TypedArray) attribute.
+function findNumericAttr(cdf)
+{
+    for (const vname of cdf.variable_names())
+    {
+        const v = cdf.get_variable(vname);
+        for (const an of v.attribute_names)
+        {
+            const av = v.attributes[an];
+            if (av !== undefined && typeof av !== "string" && av.length > 0)
+                return { vname, an, snapshot: Array.from(av) };
+        }
+    }
+    return undefined;
+}
+
+{
+    const cdf = load("a_cdf.cdf");
+    const target = findNumericAttr(cdf);
+    check("a_cdf.cdf has a numeric variable attribute", target !== undefined);
+
+    if (target)
+    {
+        const { vname, an, snapshot } = target;
+        // Re-fetch the attribute, capture the live view, then grow the heap.
+        const captured = cdf.get_variable(vname).attributes[an];
+        forceHeapGrowth();
+
+        // With the bug, `captured`'s buffer is now detached: length reads 0 and
+        // join() throws. With the fix it is an owned copy and still matches.
+        let readable = false;
+        let joined = "<threw>";
+        try
+        {
+            joined = captured.join(",");
+            readable = captured.length === snapshot.length
+                && snapshot.every((x, i) => captured[i] === x);
+        }
+        catch (e) { joined = `<threw: ${e.message}>`; }
+
+        check(`${vname}.${an} survives heap growth (join=${joined})`, readable);
+    }
+    cdf.delete();
+}
+
+if (failures > 0)
+{
+    console.error(`\n${failures} check(s) failed`);
+    process.exit(1);
+}
+console.log("\nall checks passed");

--- a/tests/wasm_attr_detach/test.mjs
+++ b/tests/wasm_attr_detach/test.mjs
@@ -9,30 +9,23 @@
 // asserts the growth actually happened (so it can't silently false-pass), and
 // checks a captured numeric attribute is still readable.
 //
-//   node test.mjs <path-to-cdfpp.js> <path-to-tests/resources>
+//   node test.mjs <path-to-cdfpp.js>
 
 import { readFileSync } from "node:fs";
-import { basename, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import process from "node:process";
 
-const [, , modulePath, resourcesDir] = process.argv;
-if (!modulePath || !resourcesDir)
+const [, , modulePath] = process.argv;
+if (!modulePath)
 {
-    console.error("usage: node test.mjs <cdfpp.js> <resources_dir>");
+    console.error("usage: node test.mjs <cdfpp.js>");
     process.exit(2);
 }
 
-// Resolve resource files inside the given directory only, ignoring any path
-// components in the requested name, so the (CLI-provided) base dir can't be
-// used to read outside the resources tree.
-const baseDir = resolve(resourcesDir);
-function resourcePath(file)
-{
-    const path = resolve(baseDir, basename(file));
-    if (path !== baseDir && !path.startsWith(baseDir + sep))
-        throw new Error(`refusing to read outside resources dir: ${file}`);
-    return path;
-}
+// Resources live alongside this test in the source tree; resolve them relative
+// to the test file rather than from a caller-supplied path.
+const resourcesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "resources");
 
 const { default: createCdfModule } = await import(modulePath);
 const Module = await createCdfModule();
@@ -51,7 +44,7 @@ function check(name, ok)
 
 function load(file)
 {
-    const bytes = new Uint8Array(readFileSync(resourcePath(file)));
+    const bytes = new Uint8Array(readFileSync(join(resourcesDir, file)));
     const cdf = Module.load(bytes);
     if (!cdf.is_valid())
         throw new Error(`failed to load ${file}`);

--- a/tests/wasm_attr_detach/test.mjs
+++ b/tests/wasm_attr_detach/test.mjs
@@ -5,13 +5,14 @@
 // data (decompression) — or any later allocation — grows the heap and detaches
 // every outstanding view, so reading such an attribute later threw
 // "Cannot perform %TypedArray%.prototype.join on a detached ArrayBuffer".
-// The fix makes attribute values owned copies. This test forces heap growth and
+// The fix makes attribute values owned copies. This test forces heap growth,
+// asserts the growth actually happened (so it can't silently false-pass), and
 // checks a captured numeric attribute is still readable.
 //
 //   node test.mjs <path-to-cdfpp.js> <path-to-tests/resources>
 
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { basename, resolve, sep } from "node:path";
 import process from "node:process";
 
 const [, , modulePath, resourcesDir] = process.argv;
@@ -19,6 +20,18 @@ if (!modulePath || !resourcesDir)
 {
     console.error("usage: node test.mjs <cdfpp.js> <resources_dir>");
     process.exit(2);
+}
+
+// Resolve resource files inside the given directory only, ignoring any path
+// components in the requested name, so the (CLI-provided) base dir can't be
+// used to read outside the resources tree.
+const baseDir = resolve(resourcesDir);
+function resourcePath(file)
+{
+    const path = resolve(baseDir, basename(file));
+    if (path !== baseDir && !path.startsWith(baseDir + sep))
+        throw new Error(`refusing to read outside resources dir: ${file}`);
+    return path;
 }
 
 const { default: createCdfModule } = await import(modulePath);
@@ -38,28 +51,35 @@ function check(name, ok)
 
 function load(file)
 {
-    const bytes = new Uint8Array(readFileSync(join(resourcesDir, file)));
+    const bytes = new Uint8Array(readFileSync(resourcePath(file)));
     const cdf = Module.load(bytes);
     if (!cdf.is_valid())
         throw new Error(`failed to load ${file}`);
     return cdf;
 }
 
-// Grow the WASM heap by allocating a large buffer inside the module. Module.load
-// copies its input into a WASM-side std::vector, so a big (invalid) input forces
-// the heap to grow well past the initial size, detaching any stale views.
-function forceHeapGrowth()
+// Grow the WASM heap past its current size. Module.load copies its input into a
+// WASM-side std::vector, so an allocation larger than the whole current heap
+// forces it to grow, detaching `witness` (a live zero-copy view over the heap).
+// Returns true only if the heap actually grew, so the caller can fail loudly
+// instead of false-passing when no detachment occurred.
+function forceHeapGrowth(witness)
 {
-    const big = Module.load(new Uint8Array(96 * 1024 * 1024));
+    const heapBytes = witness.buffer.byteLength;
+    const big = Module.load(new Uint8Array(heapBytes + 64 * 1024 * 1024));
     big.delete();
+    return witness.buffer.byteLength === 0; // detached buffers report length 0
 }
 
-// Find the first variable carrying a numeric (TypedArray) attribute.
-function findNumericAttr(cdf)
+// Find the first variable that carries a numeric (TypedArray) attribute AND has
+// a loadable values view (used as the heap-growth witness).
+function findTarget(cdf)
 {
     for (const vname of cdf.variable_names())
     {
         const v = cdf.get_variable(vname);
+        if (v.values === undefined)
+            continue;
         for (const an of v.attribute_names)
         {
             const av = v.attributes[an];
@@ -72,18 +92,24 @@ function findNumericAttr(cdf)
 
 {
     const cdf = load("a_cdf.cdf");
-    const target = findNumericAttr(cdf);
-    check("a_cdf.cdf has a numeric variable attribute", target !== undefined);
+    const target = findTarget(cdf);
+    check("a_cdf.cdf has a numeric attribute on a variable with values", target !== undefined);
 
     if (target)
     {
         const { vname, an, snapshot } = target;
-        // Re-fetch the attribute, capture the live view, then grow the heap.
-        const captured = cdf.get_variable(vname).attributes[an];
-        forceHeapGrowth();
+        // Re-fetch: capture the attribute (owned copy, under test) and a live
+        // values view (the heap-growth witness), then grow the heap.
+        const v = cdf.get_variable(vname);
+        const captured = v.attributes[an];
+        const grew = forceHeapGrowth(v.values);
 
-        // With the bug, `captured`'s buffer is now detached: length reads 0 and
-        // join() throws. With the fix it is an owned copy and still matches.
+        // Guard against a vacuous pass: if the heap didn't actually grow, the
+        // test proves nothing about detachment, so fail.
+        check(`${vname} values view detached (heap actually grew)`, grew);
+
+        // With the bug, `captured` would be detached too (join throws). With the
+        // fix it is an owned copy and still matches the snapshot.
         let readable = false;
         let joined = "<threw>";
         try

--- a/wacdfpp/meson.build
+++ b/wacdfpp/meson.build
@@ -37,5 +37,14 @@ if meson.get_compiler('cpp').get_id() == 'emscripten'
             depends: wasm_exe,
             timeout: 120,
         )
+        test('wasm_attr_detach', node,
+            args: [
+                files('../tests/wasm_attr_detach/test.mjs'),
+                meson.current_build_dir() / 'cdfpp.js',
+                meson.project_source_root() / 'tests' / 'resources',
+            ],
+            depends: wasm_exe,
+            timeout: 120,
+        )
     endif
 endif

--- a/wacdfpp/meson.build
+++ b/wacdfpp/meson.build
@@ -41,7 +41,6 @@ if meson.get_compiler('cpp').get_id() == 'emscripten'
             args: [
                 files('../tests/wasm_attr_detach/test.mjs'),
                 meson.current_build_dir() / 'cdfpp.js',
-                meson.project_source_root() / 'tests' / 'resources',
             ],
             depends: wasm_exe,
             timeout: 120,

--- a/wacdfpp/wacdfpp.cpp
+++ b/wacdfpp/wacdfpp.cpp
@@ -87,14 +87,18 @@ em::val typed_array_view(const char* ptr, std::size_t byte_count, cdf::CDF_Types
     }
 }
 
-em::val data_to_string_or_view(const cdf::data_t& data)
+// Attribute values are returned as owned copies, not zero-copy views: attribute
+// metadata is small, and a later variable load_values() (or any allocation) grows
+// the WASM heap and detaches outstanding views, which would otherwise throw
+// "detached ArrayBuffer" when the value is read back in JS.
+em::val data_to_string_or_copy(const cdf::data_t& data)
 {
     auto ptr = data.bytes_ptr();
     if (ptr == nullptr)
         return em::val::undefined();
     if (cdf::is_string(data.type()))
         return em::val(std::string(ptr, data.bytes()));
-    return typed_array_view(ptr, data.bytes(), data.type());
+    return typed_array_view(ptr, data.bytes(), data.type()).call<em::val>("slice");
 }
 
 em::val to_js_string_array(const auto& map)
@@ -156,7 +160,7 @@ struct CdfFile
         // Lazily provide attribute getter as a plain object
         auto attrs = em::val::object();
         for (const auto& [aname, attr] : var.attributes)
-            attrs.set(aname, data_to_string_or_view(attr.value()));
+            attrs.set(aname, data_to_string_or_copy(attr.value()));
         obj.set("attributes", attrs);
 
         // values: zero-copy typed array view into WASM memory
@@ -246,7 +250,7 @@ struct CdfFile
         obj.set("name", attr.name);
         auto entries = em::val::array();
         for (std::size_t i = 0; i < attr.size(); ++i)
-            entries.call<void>("push", data_to_string_or_view(attr[i]));
+            entries.call<void>("push", data_to_string_or_copy(attr[i]));
         obj.set("entries", entries);
         return obj;
     }


### PR DESCRIPTION
## Problem

Loading certain real-world CDFs in the WASM demo (e.g. THEMIS L2 EFW files) failed with:

```
Fetch error: Cannot perform %TypedArray%.prototype.join on a detached or out-of-bounds ArrayBuffer
```

## Cause

Numeric attribute values were handed to JS as **zero-copy typed-array views** into the WASM heap. In `get_variable()` those attribute views are created first, then `var.load_values()` runs — decompressing a variable's data **grows the WASM heap, which detaches every outstanding view**. When JS later reads such an attribute (the demo joins it for display), the buffer is already detached and throws. It only shows up on files large/compressed enough to actually grow the heap, which is why small test files never tripped it.

## Fix

Attribute metadata is small, so return **owned copies** (`.slice()`) instead of views — the same thing `get_variable` already does for a variable's `copy_values`. Strings were already owned. Variable bulk `values` remain zero-copy (read promptly, with `copy_values` available for retention).

## Test

Adds `tests/wasm_attr_detach/` (node, run via meson like the existing `wasm_time_conversion` test). It captures a numeric attribute, forces heap growth via a large `Module.load`, and asserts the attribute is still readable. It **fails on the old code with the exact reported error** and passes after the fix. Verified locally:

```
1/2 pycdfpp:wasm_time_conversion OK
2/2 pycdfpp:wasm_attr_detach     OK
```

HTML/demo unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)