### PR TITLE
WASM: fix wasm32 save corruption and decode time-typed attributes

### DIFF
--- a/include/cdfpp/cdf-io/saving/records-saving.hpp
+++ b/include/cdfpp/cdf-io/saving/records-saving.hpp
@@ -266,7 +266,8 @@ template <typename U>
 [[nodiscard]] std::size_t save_record(
     const cdf_VVR_t<v3x_tag>& s, const char* data, std::size_t len, U& writer)
 {
-    save_field(writer, record_size(s.header) + len);
+    save_field(
+        writer, static_cast<decltype(s.header.record_size)>(record_size(s.header) + len));
     save_field(writer, cdf_record_type::VVR);
     return writer.write(data, len);
 }

--- a/tests/full_corpus/test.py
+++ b/tests/full_corpus/test.py
@@ -72,7 +72,28 @@ class PycdfCorpus(unittest.TestCase):
         self.assertIsNotNone(cdf)
         self.assertEqual(len(cdf), variables)
         self.assertEqual(len(cdf.attributes), attrs)
-        
+
+    @ddt.data(
+        *files
+    )
+    @ddt.unpack
+    def test_save_roundtrip_remote_files(self, fname, variables, attrs):
+        print(fname)
+        original = pycdfpp.load(requests.get(f"https://129.104.27.7/data/mirrors/CDF/test_files/{fname}", verify=False).content)
+        self.assertIsNotNone(original)
+        restored = pycdfpp.load(bytes(pycdfpp.save(original)))
+        self.assertIsNotNone(restored)
+        self.assertEqual(len(original), len(restored))
+        self.assertEqual(len(original.attributes), len(restored.attributes))
+        for name in original:
+            a, b = original[name], restored[name]
+            self.assertEqual(a.type, b.type, f"{name}: type changed")
+            va, vb = np.asarray(a.values), np.asarray(b.values)
+            self.assertEqual(va.shape, vb.shape, f"{name}: shape changed")
+            equal = np.array_equal(va, vb, equal_nan=True) if va.dtype.kind == 'f' \
+                else np.array_equal(va, vb)
+            self.assertTrue(equal, f"{name}: values changed after save round-trip")
+
     def test_multithreaded_load(self):
         def load_file(fname, variables, attrs):
             cdf = pycdfpp.load(requests.get(f"https://129.104.27.7/data/mirrors/CDF/test_files/{fname}", verify=False).content)

--- a/tests/full_corpus/test.py
+++ b/tests/full_corpus/test.py
@@ -16,6 +16,12 @@ import threading
 
 os.environ['TZ'] = 'UTC'
 
+# LPP CDF test-files mirror (self-signed cert -> verify=False below).
+CORPUS_BASE_URL = "https://129.104.27.7/data/mirrors/CDF/test_files"
+
+def fetch_cdf(fname):
+    return pycdfpp.load(requests.get(f"{CORPUS_BASE_URL}/{fname}", verify=False).content)
+
 files = (
     ( "a1_k0_mpa_20050804_v02.cdf", 39, 18 ),
     ( "ac_h2_sis_20101105_v06.cdf", 61, 26 ),
@@ -68,7 +74,7 @@ class PycdfCorpus(unittest.TestCase):
     @ddt.unpack
     def test_opens_in_memory_remote_files(self, fname, variables, attrs):
         print(fname)
-        cdf = pycdfpp.load(requests.get(f"https://129.104.27.7/data/mirrors/CDF/test_files/{fname}", verify=False).content)
+        cdf = fetch_cdf(fname)
         self.assertIsNotNone(cdf)
         self.assertEqual(len(cdf), variables)
         self.assertEqual(len(cdf.attributes), attrs)
@@ -79,7 +85,7 @@ class PycdfCorpus(unittest.TestCase):
     @ddt.unpack
     def test_save_roundtrip_remote_files(self, fname, variables, attrs):
         print(fname)
-        original = pycdfpp.load(requests.get(f"https://129.104.27.7/data/mirrors/CDF/test_files/{fname}", verify=False).content)
+        original = fetch_cdf(fname)
         self.assertIsNotNone(original)
         restored = pycdfpp.load(bytes(pycdfpp.save(original)))
         self.assertIsNotNone(restored)
@@ -96,7 +102,7 @@ class PycdfCorpus(unittest.TestCase):
 
     def test_multithreaded_load(self):
         def load_file(fname, variables, attrs):
-            cdf = pycdfpp.load(requests.get(f"https://129.104.27.7/data/mirrors/CDF/test_files/{fname}", verify=False).content)
+            cdf = fetch_cdf(fname)
             self.assertIsNotNone(cdf)
             self.assertEqual(len(cdf), variables)
             self.assertEqual(len(cdf.attributes), attrs)

--- a/tests/wasm_save_roundtrip/test.mjs
+++ b/tests/wasm_save_roundtrip/test.mjs
@@ -74,7 +74,8 @@ function sameValues(a, b)
         const x = a[n], y = b[n];
         if (x === null || y === null)
             return x === y;
-        return x.length === y.length && x.every((v, i) => v === y[i]);
+        // Object.is so NaN fill values compare equal (NaN !== NaN with ===).
+        return x.length === y.length && x.every((v, i) => Object.is(v, y[i]));
     });
 }
 

--- a/tests/wasm_save_roundtrip/test.mjs
+++ b/tests/wasm_save_roundtrip/test.mjs
@@ -1,0 +1,112 @@
+// Node test: save() must round-trip on wasm32 (WASM build).
+//
+// Regression test for a 32-bit save bug. The VVR fast-path wrote the record's
+// size header as a platform-width std::size_t instead of the fixed 8-byte
+// cdf_offset_field_t. On wasm32 (size_t == 4 bytes) every VVR header was 4
+// bytes short, shifting all following record offsets and tripping the layout
+// assertion `offset - vvr.size == vvr.offset` in saving.hpp, which aborts the
+// module ("unreachable"). Native (size_t == 8 bytes) hid the bug. The fix casts
+// the value to the header's record_size type. This test saves a real file,
+// re-loads the saved bytes, and checks variable values survive the round-trip.
+//
+//   node test.mjs <path-to-cdfpp.js>
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import process from "node:process";
+
+const [, , modulePath] = process.argv;
+if (!modulePath)
+{
+    console.error("usage: node test.mjs <cdfpp.js>");
+    process.exit(2);
+}
+
+// Resources live alongside this test in the source tree; resolve them relative
+// to the test file rather than from a caller-supplied path.
+const resourcesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "resources");
+
+const { default: createCdfModule } = await import(modulePath);
+const Module = await createCdfModule();
+
+let failures = 0;
+function check(name, ok)
+{
+    if (ok)
+        console.log(`ok   ${name}`);
+    else
+    {
+        failures += 1;
+        console.error(`FAIL ${name}`);
+    }
+}
+
+function load(bytesOrFile)
+{
+    const bytes = typeof bytesOrFile === "string"
+        ? new Uint8Array(readFileSync(join(resourcesDir, bytesOrFile)))
+        : bytesOrFile;
+    const cdf = Module.load(bytes);
+    if (!cdf.is_valid())
+        throw new Error("failed to load CDF");
+    return cdf;
+}
+
+function snapshotValues(cdf)
+{
+    const snap = {};
+    for (const vname of cdf.variable_names())
+    {
+        const values = cdf.get_variable(vname).values;
+        snap[vname] = values === undefined ? null : Array.from(values);
+    }
+    return snap;
+}
+
+function sameValues(a, b)
+{
+    const names = Object.keys(a);
+    if (names.length !== Object.keys(b).length)
+        return false;
+    return names.every((n) =>
+    {
+        const x = a[n], y = b[n];
+        if (x === null || y === null)
+            return x === y;
+        return x.length === y.length && x.every((v, i) => v === y[i]);
+    });
+}
+
+// Any file with a non-empty variable exercises the VVR fast-path; this one has
+// several uncompressed variables, so it hits the bug on the very first VVR.
+const RESOURCE = "ac_h0_mfi_00000000_v01.cdf";
+
+{
+    const cdf = load(RESOURCE);
+    const before = snapshotValues(cdf);
+
+    let saved;
+    let threw = false;
+    try { saved = cdf.save(); }
+    catch (e) { threw = true; console.error(`save threw: ${e.message}`); }
+    cdf.delete();
+
+    // Pre-fix this aborts the module ("unreachable") instead of returning bytes.
+    check(`save(${RESOURCE}) does not abort`, !threw && saved !== undefined);
+
+    if (!threw && saved !== undefined)
+    {
+        const reloaded = load(new Uint8Array(saved));
+        const after = snapshotValues(reloaded);
+        reloaded.delete();
+        check("re-loaded CDF has identical variable values", sameValues(before, after));
+    }
+}
+
+if (failures > 0)
+{
+    console.error(`\n${failures} check(s) failed`);
+    process.exit(1);
+}
+console.log("\nall checks passed");

--- a/tests/wasm_time_attrs/test.mjs
+++ b/tests/wasm_time_attrs/test.mjs
@@ -1,0 +1,86 @@
+// Node test: time-typed attributes decode to ISO date strings (WASM build).
+//
+// Regression test for the demo showing raw EPOCH doubles / TT2000 counts for
+// time-typed attributes (e.g. VALIDMIN/VALIDMAX/FILLVAL on epoch variables).
+// The wrapper now decodes CDF_EPOCH / CDF_EPOCH16 / CDF_TIME_TT2000 attribute
+// values to ISO-8601 date strings (via cdfpp's repr formatters) and exposes the
+// CDF type code via `attribute_types` (variables) / `types` (global attrs).
+// Using the repr path means: full date range (a 9999-12-31 FILLVAL sentinel
+// renders correctly instead of overflowing int64 ns), exact EPOCH16 sub-second
+// nanoseconds, and output identical to pycdfpp.
+//
+// Oracle strings match pycdfpp's repr of the same attributes.
+//
+//   node test.mjs <path-to-cdfpp.js>
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import process from "node:process";
+
+const [, , modulePath] = process.argv;
+if (!modulePath)
+{
+    console.error("usage: node test.mjs <cdfpp.js>");
+    process.exit(2);
+}
+
+const resourcesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "resources");
+
+const { default: createCdfModule } = await import(modulePath);
+const Module = await createCdfModule();
+const DT = Module.DataType;
+
+let failures = 0;
+function check(name, ok)
+{
+    if (ok)
+        console.log(`ok   ${name}`);
+    else
+    {
+        failures += 1;
+        console.error(`FAIL ${name}`);
+    }
+}
+
+function load(file)
+{
+    const cdf = Module.load(new Uint8Array(readFileSync(join(resourcesDir, file))));
+    if (!cdf.is_valid())
+        throw new Error(`failed to load ${file}`);
+    return cdf;
+}
+
+// Each case: file, variable, attribute, expected CDF type, expected ISO string.
+// The thg FILLVAL is the -1e31 fill sentinel — it must render as 9999-12-31
+// (the case that previously overflowed int64 ns and wrapped to ~1677).
+const cases = [
+    ["testutf8.cdf", "ep", "dummy", DT.CDF_EPOCH.value, "2002-05-13T00:00:00.000000000"],
+    ["testutf8.cdf", "ep16", "dummy", DT.CDF_EPOCH16.value, "2002-05-13T15:08:01.002003004"],
+    ["testutf8.cdf", "tt2000", "dummy", DT.CDF_TIME_TT2000.value, "2010-05-13T10:20:30.040050060"],
+    ["ac_h0_mfi_00000000_v01.cdf", "Epoch", "VALIDMIN", DT.CDF_EPOCH.value, "1996-01-01T00:00:00.000000000"],
+    ["ac_h0_mfi_00000000_v01.cdf", "Epoch", "VALIDMAX", DT.CDF_EPOCH.value, "2020-01-01T00:00:00.000000000"],
+    ["thg_l2_mag_mek_00000000_v01.cdf", "thg_mag_mek_epoch", "FILLVAL", DT.CDF_EPOCH.value, "9999-12-31T23:59:59.999"],
+    ["thg_l2_mag_mek_00000000_v01.cdf", "thg_mag_mek_epoch", "VALIDMAX", DT.CDF_EPOCH.value, "2100-12-31T23:59:59.999000000"],
+];
+
+for (const [file, vname, aname, expType, expISO] of cases)
+{
+    const cdf = load(file);
+    const v = cdf.get_variable(vname);
+
+    check(`${file}:${vname}.${aname} type is time`, v.attribute_types[aname] === expType);
+
+    const value = v.attributes[aname];
+    check(`${file}:${vname}.${aname} decoded to ISO (${Array.isArray(value) ? value[0] : value})`,
+        Array.isArray(value) && value.length === 1 && value[0] === expISO);
+
+    cdf.delete();
+}
+
+if (failures > 0)
+{
+    console.error(`\n${failures} check(s) failed`);
+    process.exit(1);
+}
+console.log("\nall checks passed");

--- a/wacdfpp/cdfpp.d.ts
+++ b/wacdfpp/cdfpp.d.ts
@@ -38,7 +38,17 @@ export interface Variable {
     readonly compression: string;
     readonly values_loaded: boolean;
     readonly attribute_names: string[];
-    readonly attributes: Record<string, string | TypedArray>;
+    /**
+     * Attribute values keyed by name. Time-typed values (CDF_EPOCH / CDF_EPOCH16 /
+     * CDF_TIME_TT2000 — e.g. VALIDMIN/VALIDMAX/FILLVAL on epoch variables) are
+     * decoded to an array of ISO-8601 UTC date strings (leap-second corrected, full
+     * range — sentinels such as 9999-12-31 render correctly); a plain string is a
+     * text attribute; anything else is a numeric typed array. See `attribute_types`
+     * for the exact CDF type code.
+     */
+    readonly attributes: Record<string, string | TypedArray | string[]>;
+    /** CDF type code (see DataType) for each attribute in `attributes`. */
+    readonly attribute_types: Record<string, number>;
     readonly values: TypedArray | undefined;
     readonly copy_values: TypedArray | undefined;
 }
@@ -46,7 +56,13 @@ export interface Variable {
 /** A CDF global attribute with one or more entries */
 export interface Attribute {
     readonly name: string;
-    readonly entries: Array<string | TypedArray>;
+    /**
+     * Entry values. Time-typed entries are decoded to an array of ISO-8601 UTC
+     * date strings; see `types` for the CDF type code of each entry.
+     */
+    readonly entries: Array<string | TypedArray | string[]>;
+    /** CDF type code (see DataType) for each entry in `entries`. */
+    readonly types: number[];
 }
 
 /** A loaded CDF file (C++ backed — call delete() when done) */

--- a/wacdfpp/meson.build
+++ b/wacdfpp/meson.build
@@ -45,5 +45,21 @@ if meson.get_compiler('cpp').get_id() == 'emscripten'
             depends: wasm_exe,
             timeout: 120,
         )
+        test('wasm_save_roundtrip', node,
+            args: [
+                files('../tests/wasm_save_roundtrip/test.mjs'),
+                meson.current_build_dir() / 'cdfpp.js',
+            ],
+            depends: wasm_exe,
+            timeout: 120,
+        )
+        test('wasm_time_attrs', node,
+            args: [
+                files('../tests/wasm_time_attrs/test.mjs'),
+                meson.current_build_dir() / 'cdfpp.js',
+            ],
+            depends: wasm_exe,
+            timeout: 120,
+        )
     endif
 endif

--- a/wacdfpp/wacdfpp.cpp
+++ b/wacdfpp/wacdfpp.cpp
@@ -25,12 +25,14 @@
 ----------------------------------------------------------------------------*/
 #include <cdfpp/cdf.hpp>
 #include <cdfpp/cdf-io/saving/saving.hpp>
+#include <cdfpp/cdf-repr.hpp>
 #include <cdfpp/chrono/cdf-chrono.hpp>
 
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
 
 #include <cstdint>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -87,10 +89,93 @@ em::val typed_array_view(const char* ptr, std::size_t byte_count, cdf::CDF_Types
     }
 }
 
+constexpr bool is_time_type(cdf::CDF_Types type)
+{
+    using enum cdf::CDF_Types;
+    return type == CDF_EPOCH || type == CDF_EPOCH16 || type == CDF_TIME_TT2000;
+}
+
+// Decode a contiguous buffer of CDF time values (CDF_TIME_TT2000 / CDF_EPOCH /
+// CDF_EPOCH16) to leap-second-corrected UTC nanoseconds since 1970, returned as
+// an owned BigInt64Array (the JS analog of datetime64[ns]). Returns undefined
+// for non-time types or an empty buffer.
+em::val time_buffer_to_ns(const char* ptr, std::size_t byte_count, cdf::CDF_Types type)
+{
+    using enum cdf::CDF_Types;
+    if (ptr == nullptr || !is_time_type(type))
+        return em::val::undefined();
+    const std::size_t n = byte_count / cdf::cdf_type_size(type);
+    if (n == 0)
+        return em::val::undefined();
+
+    std::vector<int64_t> out(n);
+    switch (type)
+    {
+        case CDF_TIME_TT2000:
+            cdf::to_ns_from_1970(
+                std::span<const cdf::tt2000_t>(reinterpret_cast<const cdf::tt2000_t*>(ptr), n),
+                out.data());
+            break;
+        case CDF_EPOCH:
+            cdf::to_ns_from_1970(
+                std::span<const cdf::epoch>(reinterpret_cast<const cdf::epoch*>(ptr), n),
+                out.data());
+            break;
+        case CDF_EPOCH16:
+            cdf::to_ns_from_1970(
+                std::span<const cdf::epoch16>(reinterpret_cast<const cdf::epoch16*>(ptr), n),
+                out.data());
+            break;
+        default:
+            return em::val::undefined();
+    }
+    // owned BigInt64Array copy (out dies after return)
+    return em::val(em::typed_memory_view(n, out.data())).call<em::val>("slice");
+}
+
+// Decode a buffer of CDF time values to an array of ISO-8601 date strings, reusing
+// cdfpp's repr formatters (cdf-repr.hpp). Those special-case the standard CDF fill
+// sentinels (e.g. EPOCH -1e31 / TT2000 INT64_MIN -> "9999-12-31...") and handle the
+// full date range, so a VALIDMIN/VALIDMAX/FILLVAL renders exactly as in pycdfpp
+// instead of as a raw number or an int64-ns overflow.
+em::val time_buffer_to_iso(const char* ptr, std::size_t byte_count, cdf::CDF_Types type)
+{
+    using enum cdf::CDF_Types;
+    if (ptr == nullptr || !is_time_type(type))
+        return em::val::undefined();
+    const std::size_t n = byte_count / cdf::cdf_type_size(type);
+    if (n == 0)
+        return em::val::undefined();
+
+    auto arr = em::val::array();
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        std::ostringstream ss;
+        switch (type)
+        {
+            case CDF_EPOCH:
+                ss << reinterpret_cast<const cdf::epoch*>(ptr)[i];
+                break;
+            case CDF_EPOCH16:
+                ss << reinterpret_cast<const cdf::epoch16*>(ptr)[i];
+                break;
+            case CDF_TIME_TT2000:
+                ss << reinterpret_cast<const cdf::tt2000_t*>(ptr)[i];
+                break;
+            default:
+                return em::val::undefined();
+        }
+        arr.call<void>("push", ss.str());
+    }
+    return arr;
+}
+
 // Attribute values are returned as owned copies, not zero-copy views: attribute
 // metadata is small, and a later variable load_values() (or any allocation) grows
 // the WASM heap and detaches outstanding views, which would otherwise throw
-// "detached ArrayBuffer" when the value is read back in JS.
+// "detached ArrayBuffer" when the value is read back in JS. Time-typed values are
+// decoded to ISO-8601 date strings so callers get a meaningful date (full range,
+// leap-second corrected) instead of a raw EPOCH double / TT2000 count.
 em::val data_to_string_or_copy(const cdf::data_t& data)
 {
     auto ptr = data.bytes_ptr();
@@ -98,6 +183,8 @@ em::val data_to_string_or_copy(const cdf::data_t& data)
         return em::val::undefined();
     if (cdf::is_string(data.type()))
         return em::val(std::string(ptr, data.bytes()));
+    if (is_time_type(data.type()))
+        return time_buffer_to_iso(ptr, data.bytes(), data.type());
     return typed_array_view(ptr, data.bytes(), data.type()).call<em::val>("slice");
 }
 
@@ -157,11 +244,18 @@ struct CdfFile
 
         obj.set("attribute_names", to_js_string_array(var.attributes));
 
-        // Lazily provide attribute getter as a plain object
+        // Lazily provide attribute getter as a plain object, plus a parallel map
+        // of CDF type codes so callers can tell e.g. a time-typed VALIDMIN
+        // (returned as ns-since-1970) from a plain numeric attribute.
         auto attrs = em::val::object();
+        auto attr_types = em::val::object();
         for (const auto& [aname, attr] : var.attributes)
+        {
             attrs.set(aname, data_to_string_or_copy(attr.value()));
+            attr_types.set(aname, static_cast<int>(attr.value().type()));
+        }
         obj.set("attributes", attrs);
+        obj.set("attribute_types", attr_types);
 
         // values: zero-copy typed array view into WASM memory
         var.load_values();
@@ -188,7 +282,6 @@ struct CdfFile
     // This is the JS analog of pycdfpp's datetime64[ns].
     em::val time_values_as_ns_since_1970(const std::string& name)
     {
-        using enum cdf::CDF_Types;
         if (!cdf)
             return em::val::undefined();
         auto it = cdf->variables.find(name);
@@ -196,45 +289,11 @@ struct CdfFile
             return em::val::undefined();
 
         auto& var = it->second;
-        const auto type = var.type();
-        if (type != CDF_TIME_TT2000 && type != CDF_EPOCH && type != CDF_EPOCH16)
+        if (!is_time_type(var.type()))
             return em::val::undefined();
 
         var.load_values();
-        const auto* ptr = var.bytes_ptr();
-        if (ptr == nullptr)
-            return em::val::undefined();
-
-        const std::size_t n = var.bytes() / cdf::cdf_type_size(type);
-        if (n == 0)
-            return em::val::undefined();
-
-        std::vector<int64_t> out(n);
-        switch (type)
-        {
-            case CDF_TIME_TT2000:
-                cdf::to_ns_from_1970(
-                    std::span<const cdf::tt2000_t>(
-                        reinterpret_cast<const cdf::tt2000_t*>(ptr), n),
-                    out.data());
-                break;
-            case CDF_EPOCH:
-                cdf::to_ns_from_1970(
-                    std::span<const cdf::epoch>(reinterpret_cast<const cdf::epoch*>(ptr), n),
-                    out.data());
-                break;
-            case CDF_EPOCH16:
-                cdf::to_ns_from_1970(
-                    std::span<const cdf::epoch16>(
-                        reinterpret_cast<const cdf::epoch16*>(ptr), n),
-                    out.data());
-                break;
-            default:
-                return em::val::undefined();
-        }
-
-        // owned BigInt64Array copy (out dies after return)
-        return em::val(em::typed_memory_view(n, out.data())).call<em::val>("slice");
+        return time_buffer_to_ns(var.bytes_ptr(), var.bytes(), var.type());
     }
 
     em::val get_attribute(const std::string& name) const
@@ -249,9 +308,14 @@ struct CdfFile
         auto obj = em::val::object();
         obj.set("name", attr.name);
         auto entries = em::val::array();
+        auto types = em::val::array();
         for (std::size_t i = 0; i < attr.size(); ++i)
+        {
             entries.call<void>("push", data_to_string_or_copy(attr[i]));
+            types.call<void>("push", static_cast<int>(attr[i].type()));
+        }
         obj.set("entries", entries);
+        obj.set("types", types);
         return obj;
     }
 

--- a/wacdfpp/wacdfpp.cpp
+++ b/wacdfpp/wacdfpp.cpp
@@ -246,7 +246,7 @@ struct CdfFile
 
         // Lazily provide attribute getter as a plain object, plus a parallel map
         // of CDF type codes so callers can tell e.g. a time-typed VALIDMIN
-        // (returned as ns-since-1970) from a plain numeric attribute.
+        // (returned as ISO date strings) from a plain numeric attribute.
         auto attrs = em::val::object();
         auto attr_types = em::val::object();
         for (const auto& [aname, attr] : var.attributes)

--- a/wacdfpp/wacdfpp.html
+++ b/wacdfpp/wacdfpp.html
@@ -311,6 +311,16 @@
         return d.toISOString().replace('Z', '') + rem.toString().padStart(6, '0') + 'Z';
     }
 
+    // Render one attribute value. Time-typed values (VALIDMIN/VALIDMAX/FILLVAL on
+    // epoch variables, etc.) arrive already decoded as an array of ISO date
+    // strings; a plain string is a text attribute; anything else is a numeric
+    // typed array.
+    function formatAttrValue(value) {
+        if (typeof value === 'string') return `"${esc(value.trim())}"`;
+        if (Array.isArray(value)) return value.map(esc).join(', ');
+        return value;
+    }
+
     // Drop trailing null padding then trailing whitespace, without regex
     // (Sonar flags `+$` patterns as potential ReDoS).
     function stripPadding(s) {
@@ -382,8 +392,7 @@
         log(span('log-section', `[ Global Attributes ] `) + span('log-dim', `(${attrNames.length})`));
         for (const name of attrNames) {
             const attr = cdf.get_attribute(name);
-            const entries = attr.entries.map(v =>
-                typeof v === 'string' ? `"${esc(v.trim())}"` : v);
+            const entries = attr.entries.map(formatAttrValue);
             log(`  ${span('log-key', esc(name))}  ${span('log-dim', entries.join(', '))}`);
         }
 
@@ -395,19 +404,11 @@
             log(`  ${span('log-key', esc(name))}  ${span('log-dim', `[${v.shape}]`)} ${span('log-val', v.type_name)}${v.is_nrv ? span('log-dim', ' nrv') : ''}`);
 
             for (const an of v.attribute_names) {
-                const av = v.attributes[an];
-                const display = typeof av === 'string' ? `"${esc(av.trim())}"` : av;
+                const display = formatAttrValue(v.attributes[an]);
                 log(`    ${span('log-dim', esc(an) + ':')} ${display}`);
             }
 
             logValuePreview(cdf, v);
-        }
-
-        const savedBytes = cdf.save();
-        if (savedBytes !== undefined) {
-            log('');
-            log(span('log-section', '[ Round-trip ]'));
-            log(`  Save size  ${span('log-val', savedBytes.length.toLocaleString() + ' bytes')}`);
         }
 
         cdf.delete();


### PR DESCRIPTION
Three related WASM wrapper/demo fixes, found while loading a real THEMIS CDF in the [GH Pages demo](https://sciqlop.github.io/CDFpp/) — which reported **"Fetch error: unreachable"** after otherwise displaying the file correctly.

## 1. Fix wasm32 CDF save corruption (the actual crash)

The VVR fast-path wrote the record-size header as a platform-width `std::size_t`:

```cpp
save_field(writer, record_size(s.header) + len);   // std::size_t
```

`save_field` writes `sizeof(std::size_t)` bytes — 8 on native, **4 on wasm32**. The VVR header `record_size` field is a fixed 8-byte `cdf_offset_field_t<v3>`, so on wasm32 every VVR header was written 4 bytes short, shifting all following record offsets and tripping the layout assertion `offset - vvr.size == vvr.offset` in `saving.hpp` → `abort()` → JS `unreachable`. Native release builds compile the assert out (`NDEBUG`) and silently produced a similarly-shifted file; `emcc -O2` keeps asserts live, so it aborts. The fix casts to the header's fixed-width type, mirroring `save_header`.

The demo surfaced this because `inspectCdf()` ran a round-trip `cdf.save()` inside the fetch `try/catch`, so the save abort was mislabeled as a fetch error.

## 2. Drop the round-trip save from the demo

It ran on every inspection, only ever became visible *on failure*, and slowed things down. Save correctness belongs in CI, not a viewer — so this PR adds:
- `tests/wasm_save_roundtrip` — wasm32 round-trip regression test (aborts before the fix, passes after).
- a corpus-wide save round-trip test in `tests/full_corpus` (load → save → reload → compare values).

## 3. Decode time-typed attributes in the wrapper/demo

`VALIDMIN`/`VALIDMAX`/`FILLVAL` etc. on epoch variables were shown as raw `EPOCH` doubles / `TT2000` counts. They now decode to ISO date strings via cdfpp's own `cdf-repr.hpp` formatters — the same path pycdfpp uses — which cover the full date range and the standard CDF fill sentinels (e.g. `EPOCH` `-1e31` and `TT2000` `INT64_MIN` → `9999-12-31`). The wrapper also exposes attribute CDF type codes (`attribute_types` on variables, `types` on global attributes).

`tests/wasm_time_attrs` asserts exact decoded strings across all three time types plus a `9999-12-31` fill sentinel and a `2100` near-edge.

## Tests
- wasm: `wasm_time_conversion`, `wasm_save_roundtrip`, `wasm_time_attrs`, `wasm_attr_detach` — all pass.
- native: full suite passes (the save cast is a no-op where `size_t` is 8 bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)