### PR TITLE
CDFpp Explorer: gate plot + value table to low-rank, bounded-size variables

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -61,22 +61,22 @@ node = find_program('node', required: false)
 if node.found()
     test('wacdfpp_model', node,
         args: [files('wacdfpp_model/test.mjs')],
-        timeout: 10,
+        timeout: 60,
     )
     test('wacdfpp_format', node,
         args: [files('wacdfpp_format/test.mjs')],
-        timeout: 10,
+        timeout: 60,
     )
     test('wacdfpp_plot', node,
         args: [files('wacdfpp_plot/test.mjs')],
-        timeout: 10,
+        timeout: 60,
     )
     test('wacdfpp_astralint', node,
         args: [files('wacdfpp_astralint/test.mjs')],
-        timeout: 10,
+        timeout: 60,
     )
     test('wacdfpp_diff', node,
         args: [files('wacdfpp_diff/test.mjs')],
-        timeout: 10,
+        timeout: 60,
     )
 endif

--- a/tests/wacdfpp_format/test.mjs
+++ b/tests/wacdfpp_format/test.mjs
@@ -1,6 +1,7 @@
 // Pure Node test for wacdfpp/render.js formatters — no WASM, no DOM.
 //   node test.mjs
-import { nsToISO, stripPadding, chunkRecords, decodeChars, formatAttrValue } from "../../wacdfpp/render.js";
+import { nsToISO, stripPadding, chunkRecords, decodeChars, formatAttrValue,
+         previewability, MAX_PREVIEW_DIMENSIONS, MAX_PREVIEW_POINTS } from "../../wacdfpp/render.js";
 
 let failures = 0;
 function check(name, ok) {
@@ -36,5 +37,15 @@ check("decodeChars total", decodeChars(twoRec, [5]).total === 2);
 check("decodeChars max clamp", decodeChars(twoRec, [5], 1).strings.length === 1);
 const padded = new Uint8Array([72, 101, 0, 0, 0, 87, 0, 0, 0, 0]); // "He","W" null-padded
 check("decodeChars strips null padding", eq(decodeChars(padded, [5]).strings, ["He", "W"]));
+
+// previewability gate: high-rank / oversized variables skip the value table
+check("MAX_PREVIEW_DIMENSIONS is 2", MAX_PREVIEW_DIMENSIONS === 2);
+check("1-D previewable", previewability([100]).ok === true);
+check("2-D previewable", previewability([100, 32]).ok === true);
+check("3-D not previewable", previewability([10, 16, 32]).ok === false);
+check("5-D particle dist not previewable", previewability([100, 32, 16, 32, 8]).ok === false);
+check("high-D reason is a string", typeof previewability([10, 16, 32]).reason === "string");
+check("oversized 2-D not previewable", previewability([MAX_PREVIEW_POINTS, 2]).ok === false);
+check("within rank+size previewable", previewability([1000, 100]).ok === true);
 
 process.exit(failures ? 1 : 0);

--- a/tests/wacdfpp_plot/test.mjs
+++ b/tests/wacdfpp_plot/test.mjs
@@ -1,7 +1,8 @@
 // Pure Node test for wacdfpp/plot-model.js and the pure helpers of spectrogram.js.
 //   node test.mjs
 import {
-    MAX_LINES, recordLength, plotSpec, applyMask, decimateMinMax, toCSV, toJSON,
+    MAX_LINES, MAX_PLOT_DIMENSIONS, MAX_PLOT_POINTS,
+    recordLength, plotSpec, applyMask, decimateMinMax, toCSV, toJSON,
 } from "../../wacdfpp/plot-model.js";
 import { viridis, normalizeLevel, cellEdges, scaleTypeOf, isMonotonic } from "../../wacdfpp/spectrogram.js";
 
@@ -48,6 +49,23 @@ check("char type -> none", plotSpec({ type: 51, shape: [10, 16], attributes: {} 
 check("zero records -> none", plotSpec({ type: 21, shape: [0, 3], attributes: {} }).kind === "none");
 check("empty shape var still plottable as line",
     plotSpec({ type: 21, shape: [5], attributes: {} }).kind === "line");
+
+// dimension + size gating: high-D (e.g. 4-5D particle distributions) and oversized
+// variables would crash copy_values / produce meaningless plots — gate to none.
+check("3-D var -> none", plotSpec({ type: 21, shape: [10, 16, 32], attributes: {} }).kind === "none");
+check("5-D particle dist -> none",
+    plotSpec({ type: 21, shape: [100, 32, 16, 32, 8], attributes: {} }).kind === "none");
+check("high-D none carries a reason",
+    typeof plotSpec({ type: 21, shape: [10, 16, 32], attributes: {} }).reason === "string");
+check("high-D gate ignores override",
+    plotSpec({ type: 21, shape: [10, 16, 32], attributes: {} }, "line").kind === "none");
+check("oversized 2-D var -> none",
+    plotSpec({ type: 21, shape: [MAX_PLOT_POINTS, 2], attributes: {} }).kind === "none");
+check("oversized gate ignores override",
+    plotSpec({ type: 21, shape: [MAX_PLOT_POINTS, 2], attributes: {} }, "spectrogram").kind === "none");
+check("within rank + size still plottable",
+    plotSpec({ type: 21, shape: [1000, 32], attributes: {} }).kind !== "none");
+check("MAX_PLOT_DIMENSIONS is 2", MAX_PLOT_DIMENSIONS === 2);
 
 // resolved fields surface DEPEND_*/LABL_PTR_1 and numeric FILLVAL
 const spec = plotSpec({

--- a/wacdfpp/plot-model.js
+++ b/wacdfpp/plot-model.js
@@ -3,8 +3,20 @@
 // in plot.js. Unit-tested in Node (tests/wacdfpp_plot).
 
 export const MAX_LINES = 8;
+// Only 1-D time series and 2-D spectrograms are drawable. Higher-rank variables
+// (e.g. 4-5D particle distributions) have no sensible 2-D rendering and would
+// crash when their whole value array is materialized — so they are gated out.
+export const MAX_PLOT_DIMENSIONS = 2;     // max shape rank (record dim + 1)
+export const MAX_PLOT_POINTS = 10_000_000; // max total elements (product of shape)
 export const TIME_TYPES = new Set([31, 32, 33]); // CDF_EPOCH, EPOCH16, TT2000
 export const CHAR_TYPES = new Set([51, 52]);     // CDF_CHAR, CDF_UCHAR
+
+// Total element count = product of all dims (cheap; computed from shape, never
+// from the materialized values).
+export function totalElements(shape) {
+    if (!shape || shape.length === 0) return 0;
+    return shape.reduce((a, b) => a * b, 1);
+}
 
 // Record length = product of non-record dims (shape[1:]); 1 for 0/1-D records.
 export function recordLength(shape) {
@@ -40,6 +52,12 @@ export function plotSpec(variable, override) {
         return { ...base, kind: "none", reason: "character data is not plottable" };
     if (!variable.shape || variable.shape.length === 0 || (variable.shape[0] ?? 0) === 0)
         return { ...base, kind: "none", reason: "no records to plot" };
+    if (variable.shape.length > MAX_PLOT_DIMENSIONS)
+        return { ...base, kind: "none",
+            reason: `${variable.shape.length}-dimensional data is not plottable (only time series and spectrograms are supported)` };
+    if (totalElements(variable.shape) > MAX_PLOT_POINTS)
+        return { ...base, kind: "none",
+            reason: `too large to plot (${totalElements(variable.shape).toLocaleString()} values)` };
 
     let kind;
     if (override === "line" || override === "spectrogram") {

--- a/wacdfpp/plot.js
+++ b/wacdfpp/plot.js
@@ -366,6 +366,13 @@ export function renderPlot(mount, cdf, name) {
     if (!v) return;
 
     const meta = { type: v.type, shape: Array.from(v.shape), attributes: v.attributes };
+
+    // Gate from metadata BEFORE materializing values: copy_values copies the whole
+    // variable, so a high-rank/oversized distribution would OOM here. plotSpec (no
+    // override) returns kind "none" for char, empty, >2-D and over-size variables.
+    const gate = plotSpec(meta);
+    if (gate.kind === "none") { mount.appendChild(note(gate.reason || "not plottable")); return; }
+
     const values = v.copy_values ? Float64Array.from(v.copy_values, Number) : new Float64Array(0);
     const x = resolveXAxis(cdf, meta);
 

--- a/wacdfpp/render.js
+++ b/wacdfpp/render.js
@@ -168,6 +168,12 @@ function previewTable(cdf, v) {
     const table = document.createElement("table");
     table.className = "preview";
 
+    // Gate first, before ANY value-reading branch (time / char / numeric) — each of
+    // them materializes the whole variable, so a high-rank or huge variable of any
+    // type must be stopped here.
+    const prev = previewability(v.shape);
+    if (!prev.ok) return { table: null, total: v.shape[0] ?? 0, shown: 0, reason: prev.reason };
+
     if (isTimeType(v.type)) {
         const ns = cdf.time_values_as_ns_since_1970(v.name);
         const total = ns ? ns.length : 0;
@@ -189,9 +195,6 @@ function previewTable(cdf, v) {
         });
         return { table, total, shown: strings.length };
     }
-
-    const prev = previewability(v.shape);
-    if (!prev.ok) return { table: null, total: v.shape[0] ?? 0, shown: 0, reason: prev.reason };
 
     const values = v.copy_values;
     if (values === undefined || values.length === 0) return { table, total: 0, shown: 0 };

--- a/wacdfpp/render.js
+++ b/wacdfpp/render.js
@@ -146,6 +146,22 @@ function recordLength(shape) {
     return shape.slice(1).reduce((a, b) => a * b, 1);
 }
 
+// Value-preview gate: the table reads the WHOLE variable (copy_values) and joins
+// every record's elements, so high-rank (e.g. 4-5D particle distributions) or huge
+// variables would crash / produce unreadable rows. Decided from shape alone, before
+// any values are read.
+export const MAX_PREVIEW_DIMENSIONS = 2;     // max shape rank (record dim + 1)
+export const MAX_PREVIEW_POINTS = 2_000_000; // max total elements (product of shape)
+
+export function previewability(shape) {
+    if (shape && shape.length > MAX_PREVIEW_DIMENSIONS)
+        return { ok: false, reason: `${shape.length}-dimensional data — value preview not shown` };
+    const total = shape && shape.length ? shape.reduce((a, b) => a * b, 1) : 0;
+    if (total > MAX_PREVIEW_POINTS)
+        return { ok: false, reason: `too large to preview (${total.toLocaleString()} values)` };
+    return { ok: true };
+}
+
 const PREVIEW_RECORDS = 20;
 
 function previewTable(cdf, v) {
@@ -173,6 +189,9 @@ function previewTable(cdf, v) {
         });
         return { table, total, shown: strings.length };
     }
+
+    const prev = previewability(v.shape);
+    if (!prev.ok) return { table: null, total: v.shape[0] ?? 0, shown: 0, reason: prev.reason };
 
     const values = v.copy_values;
     if (values === undefined || values.length === 0) return { table, total: 0, shown: 0 };
@@ -235,7 +254,15 @@ export function renderDetail(container, cdf, name) {
     }
     container.append(sectionLabel("Attributes"), attrs);
 
-    const { table, total, shown } = previewTable(cdf, v);
-    container.appendChild(sectionLabel(`Values (showing ${shown} of ${total})`));
-    container.appendChild(table);
+    const { table, total, shown, reason } = previewTable(cdf, v);
+    if (reason) {
+        container.appendChild(sectionLabel(`Values (${total} records)`));
+        const skipped = document.createElement("div");
+        skipped.className = "plot-note";
+        skipped.textContent = reason;
+        container.appendChild(skipped);
+    } else {
+        container.appendChild(sectionLabel(`Values (showing ${shown} of ${total})`));
+        container.appendChild(table);
+    }
 }


### PR DESCRIPTION
## Problem

Selecting a high-rank variable (e.g. a 4–5D full particle distribution) in the CDFpp Explorer **crashed** the app, and even when it didn't, a >2-D variable has no meaningful time-series/spectrogram rendering. Both the plot (`renderPlot`) and the value-preview table call `copy_values`, which materializes the **entire** variable — for a large distribution that alone OOMs, before any dimension logic runs.

## Fix

Gate from **shape metadata, before any values are read**:

- **Plot** (`plot-model.js` → `plot.js`): `plotSpec` now returns `kind: "none"` with a reason when the shape rank exceeds `MAX_PLOT_DIMENSIONS` (2) or the total element count exceeds `MAX_PLOT_POINTS` (10,000,000). `renderPlot` consults it up front and shows the reason instead of fetching values.
- **Value table** (`render.js`): new pure `previewability(shape)` gate (`MAX_PREVIEW_DIMENSIONS` = 2, `MAX_PREVIEW_POINTS` = 2,000,000); the detail panel shows a short notice instead of the value table when exceeded.

Rank ≤ 2 keeps 1-D line plots and 2-D spectrograms working; ≥3-D is gated for both views. Thresholds are named constants, easy to tune.

## Tests

- Pure Node tests extended: `wacdfpp_plot` (rank/size gating in `plotSpec`) and `wacdfpp_format` (`previewability`). All green.
- **Browser-verified (Playwright)** on `a_compressed_cdf.cdf`: `var3d` (rank 3) gates both the plot and the table with clear notes and renders no canvas/table; `var2d` (rank 2) and `var` (1-D) still plot and show value tables; zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)